### PR TITLE
Remove redundant edges

### DIFF
--- a/src/annis/db/aql/operators/identical_cov.rs
+++ b/src/annis/db/aql/operators/identical_cov.rs
@@ -93,7 +93,7 @@ impl Operator for IdenticalCoverage {
             }
 
             // find left-aligned non-token
-            let v = self.gs_left.get_outgoing_edges(n_left);
+            let v = self.gs_left.get_ingoing_edges(n_left);
             for c in v {
                 // check if also right-aligned
                 if let Some(c_right) = self.tok_helper.right_token_for(c) {

--- a/src/annis/db/aql/operators/inclusion.rs
+++ b/src/annis/db/aql/operators/inclusion.rs
@@ -184,7 +184,7 @@ impl Operator for Inclusion {
             } else {
                 let covered_token_per_node: f64 = stats_cov.fan_out_99_percentile as f64;
                 let aligned_non_token: f64 =
-                    covered_token_per_node * (stats_left.fan_out_99_percentile as f64);
+                    covered_token_per_node * (stats_left.inverse_fan_out_99_percentile as f64);
 
                 let sum_included = covered_token_per_node + aligned_non_token;
                 return EstimationType::SELECTIVITY(sum_included / (stats_cov.nodes as f64));

--- a/src/annis/db/aql/operators/inclusion.rs
+++ b/src/annis/db/aql/operators/inclusion.rs
@@ -112,7 +112,7 @@ impl Operator for Inclusion {
                     .flat_map(move |t| {
                         let it_aligned =
                             self.gs_left
-                                .get_outgoing_edges(t)
+                                .get_ingoing_edges(t)
                                 .into_iter()
                                 .filter(move |n| {
                                     // right-aligned token of candidate

--- a/src/annis/db/aql/operators/overlap.rs
+++ b/src/annis/db/aql/operators/overlap.rs
@@ -17,7 +17,6 @@ pub struct OverlapSpec;
 pub struct Overlap {
     gs_order: Arc<GraphStorage>,
     gs_cov: Arc<GraphStorage>,
-    gs_invcov: Arc<GraphStorage>,
     tok_helper: TokenHelper,
 }
 
@@ -36,13 +35,6 @@ lazy_static! {
             name: String::from(""),
         }
     };
-    static ref COMPONENT_INV_COVERAGE: Component = {
-        Component {
-            ctype: ComponentType::InverseCoverage,
-            layer: String::from("annis"),
-            name: String::from(""),
-        }
-    };
 }
 
 impl OperatorSpec for OverlapSpec {
@@ -50,7 +42,6 @@ impl OperatorSpec for OverlapSpec {
         let mut v: Vec<Component> = vec![
             COMPONENT_ORDER.clone(),
             COMPONENT_COVERAGE.clone(),
-            COMPONENT_INV_COVERAGE.clone(),
         ];
         v.append(&mut token_helper::necessary_components());
         v
@@ -70,14 +61,12 @@ impl Overlap {
     pub fn new(db: &Graph) -> Option<Overlap> {
         let gs_order = db.get_graphstorage(&COMPONENT_ORDER)?;
         let gs_cov = db.get_graphstorage(&COMPONENT_COVERAGE)?;
-        let gs_invcov = db.get_graphstorage(&COMPONENT_INV_COVERAGE)?;
 
         let tok_helper = TokenHelper::new(db)?;
 
         Some(Overlap {
             gs_order,
             gs_cov,
-            gs_invcov,
             tok_helper,
         })
     }
@@ -108,8 +97,8 @@ impl Operator for Overlap {
         for t in covered {
             // get all nodes that are covering the token
             for n in self
-                .gs_invcov
-                .find_connected(t, 1, std::ops::Bound::Included(1))
+                .gs_cov
+                .find_connected_inverse(t, 1, std::ops::Bound::Included(1))
                 .fuse()
             {
                 result.insert(n);
@@ -152,10 +141,9 @@ impl Operator for Overlap {
     }
 
     fn estimation_type(&self) -> EstimationType {
-        if let (Some(stats_cov), Some(stats_order), Some(stats_invcov)) = (
+        if let (Some(stats_cov), Some(stats_order)) = (
             self.gs_cov.get_statistics(),
             self.gs_order.get_statistics(),
-            self.gs_invcov.get_statistics(),
         ) {
             let num_of_token = stats_order.nodes as f64;
             if stats_cov.nodes == 0 {
@@ -165,7 +153,7 @@ impl Operator for Overlap {
                 let covered_token_per_node: f64 = stats_cov.fan_out_99_percentile as f64;
                 // for each covered token get the number of inverse covered non-token nodes
                 let aligned_non_token: f64 =
-                    covered_token_per_node * (stats_invcov.fan_out_99_percentile as f64);
+                    covered_token_per_node * (stats_cov.inverse_fan_out_99_percentile as f64);
 
                 let sum_included = covered_token_per_node + aligned_non_token;
                 return EstimationType::SELECTIVITY(sum_included / (stats_cov.nodes as f64));

--- a/src/annis/db/aql/operators/precedence.rs
+++ b/src/annis/db/aql/operators/precedence.rs
@@ -137,7 +137,7 @@ impl Operator for Precedence {
             .fuse()
             // find all left aligned nodes for this token and add it together with the token itself
             .flat_map(move |t| {
-                let it_aligned = self.gs_left.get_outgoing_edges(t);
+                let it_aligned = self.gs_left.get_ingoing_edges(t);
                 std::iter::once(t).chain(it_aligned)
             })
             // map the result as match
@@ -241,7 +241,7 @@ impl Operator for InversePrecedence {
             .fuse()
             // find all right aligned nodes for this token and add it together with the token itself
             .flat_map(move |t| {
-                let it_aligned = self.gs_right.get_outgoing_edges(t);
+                let it_aligned = self.gs_right.get_ingoing_edges(t);
                 std::iter::once(t).chain(it_aligned)
             })
             // map the result as match

--- a/src/annis/db/corpusstorage.rs
+++ b/src/annis/db/corpusstorage.rs
@@ -68,6 +68,8 @@ pub struct GraphStorageInfo {
     pub load_status: LoadStatus,
     /// Number of edge annotations in this graph storage.
     pub number_of_annotations: usize,
+    /// Name of the implementation
+    pub implementation: String,
 }
 
 impl fmt::Display for GraphStorageInfo {
@@ -77,6 +79,7 @@ impl fmt::Display for GraphStorageInfo {
             "Component {}: {} annnotations",
             self.component, self.number_of_annotations
         )?;
+        writeln!(f, "Implementation: {}", self.implementation)?;
         match self.load_status {
             LoadStatus::NotLoaded => writeln!(f, "Not Loaded")?,
             LoadStatus::PartiallyLoaded(memory_size) => {
@@ -361,6 +364,7 @@ impl CorpusStorage {
                             component: c.clone(),
                             load_status: LoadStatus::FullyLoaded(gs.size_of(mem_ops)),
                             number_of_annotations: gs.get_anno_storage().number_of_annotations(),
+                            implementation: gs.serialization_id().clone(),
                         });
                     } else {
                         load_status = LoadStatus::PartiallyLoaded(heap_size);
@@ -368,6 +372,7 @@ impl CorpusStorage {
                             component: c.clone(),
                             load_status: LoadStatus::NotLoaded,
                             number_of_annotations: 0,
+                            implementation: "".to_owned(),
                         })
                     }
                 }

--- a/src/annis/db/graphstorage/mod.rs
+++ b/src/annis/db/graphstorage/mod.rs
@@ -22,6 +22,10 @@ pub struct GraphStatistic {
     pub avg_fan_out: f64,
     /// Max fan-out of 99% of the data.
     pub fan_out_99_percentile: usize,
+
+    /// Max inverse fan-out of 99% of the data.
+    pub inverse_fan_out_99_percentile: usize,
+
     /// Maximal number of children of a node.
     pub max_fan_out: usize,
     /// Maximum length from a root node to a terminal node.

--- a/src/annis/db/relannis.rs
+++ b/src/annis/db/relannis.rs
@@ -325,10 +325,6 @@ where
                         source: *n,
                         target: *current_token,
                     });
-                    gs_left.add_edge(Edge {
-                        source: *current_token,
-                        target: *n,
-                    });
                 }
             }
             // find all nodes that end together with the current token
@@ -348,10 +344,6 @@ where
                     gs_right.add_edge(Edge {
                         source: *n,
                         target: *current_token,
-                    });
-                    gs_right.add_edge(Edge {
-                        source: *current_token,
-                        target: *n,
                     });
                 }
             }

--- a/src/annis/db/relannis.rs
+++ b/src/annis/db/relannis.rs
@@ -406,15 +406,9 @@ where
         layer: String::from("annis"),
         name: String::from(""),
     };
-    let component_inv_cov = Component {
-        ctype: ComponentType::InverseCoverage,
-        layer: String::from("annis"),
-        name: String::from(""),
-    };
 
     // make sure the components exists, even if they are empty
     db.get_or_create_writable(&component_coverage)?;
-    db.get_or_create_writable(&component_inv_cov)?;
 
     {
         progress_callback("calculating the automatically generated COVERAGE edges");
@@ -475,20 +469,11 @@ where
                             format!("Can't get token ID for position {:?}", tok_idx)
                         })?;
                         if *n != *tok_id {
-                            {
-                                let gs = db.get_or_create_writable(&component_coverage)?;
-                                gs.add_edge(Edge {
-                                    source: *n,
-                                    target: *tok_id,
-                                });
-                            }
-                            {
-                                let gs = db.get_or_create_writable(&component_inv_cov)?;
-                                gs.add_edge(Edge {
-                                    source: *tok_id,
-                                    target: *n,
-                                });
-                            }
+                            let gs = db.get_or_create_writable(&component_coverage)?;
+                            gs.add_edge(Edge {
+                                source: *n,
+                                target: *tok_id,
+                            });
                         }
                     }
                 } // end if not a token

--- a/src/annis/types.rs
+++ b/src/annis/types.rs
@@ -99,8 +99,6 @@ impl Edge {
 pub enum ComponentType {
     /// Edges between a span node and its tokens. Implies text coverage.
     Coverage,
-    /// Edges between a token and a span node.
-    InverseCoverage,
     /// Edges between a structural node and any other structural node, span or token. Implies text coverage.
     Dominance,
     /// Edge between any node.


### PR DESCRIPTION
Since inverse edge access is now possible, some parts of the graphANNIS data model have become redundant.

- the `COVERAGE_INVERSE` component can be replaced with `COVERAGE`
- the `LEFT_TOKEN`/`RIGHT_TOKEN`used to contain the inverse edges as well, which is not necessary any longer

This helps to reduce memory usage especially for corpora with a lot of spans. E.g. the Ridges V7 corpus now uses 1770.65 MB instead of 2403.94 MB (247.35 MB used to be the inverse coverage component and the left/right token components have been both cut in half from their original 422.32 MB).
The affected component types should practically using the adjacency list implementation and therefore the should be no performance penalty for querying the inverse edges.