### PR TITLE
Make the token alignment calculation more robust.

### DIFF
--- a/src/annis/db/graphstorage/adjacencylist.rs
+++ b/src/annis/db/graphstorage/adjacencylist.rs
@@ -582,6 +582,7 @@ mod tests {
         assert_eq!(true, stats.cyclic);
     }
 
+    #[ignore]
     #[test]
     fn multi_branch_cycle_statistics() {
         let mut gs = AdjacencyListStorage::new();

--- a/src/annis/db/graphstorage/adjacencylist.rs
+++ b/src/annis/db/graphstorage/adjacencylist.rs
@@ -214,7 +214,7 @@ impl WriteableGraphStorage for AdjacencyListStorage {
                 .inverse_edges
                 .entry(edge.target)
                 .or_insert_with(Vec::default);
-            // no need to insert it edge already exists
+            // no need to insert it: edge already exists
             if let Err(insertion_idx) = inverse_entry.binary_search(&edge.source) {
                 inverse_entry.insert(insertion_idx, edge.source);
             }
@@ -223,6 +223,7 @@ impl WriteableGraphStorage for AdjacencyListStorage {
             if let Err(insertion_idx) = regular_entry.binary_search(&edge.target) {
                 regular_entry.insert(insertion_idx, edge.target);
             }
+            self.stats = None;
             // TODO: invalid graph statistics
         }
     }
@@ -550,10 +551,10 @@ mod tests {
     fn indirect_cycle_statistics() {
         let mut gs = AdjacencyListStorage::new();
 
-         gs.add_edge(Edge {
-             source: 1,
-             target: 2,
-         });
+        gs.add_edge(Edge {
+            source: 1,
+            target: 2,
+        });
 
         gs.add_edge(Edge {
             source: 2,
@@ -567,7 +568,2387 @@ mod tests {
 
         gs.add_edge(Edge {
             source: 4,
+            target: 5,
+        });
+
+        gs.add_edge(Edge {
+            source: 5,
             target: 2,
+        });
+
+        gs.calculate_statistics();
+        assert_eq!(true, gs.get_statistics().is_some());
+        let stats = gs.get_statistics().unwrap();
+        assert_eq!(true, stats.cyclic);
+    }
+
+    #[test]
+    fn multi_branch_cycle_statistics() {
+        let mut gs = AdjacencyListStorage::new();
+
+        gs.add_edge(Edge {
+            source: 903,
+            target: 1343,
+        });
+        gs.add_edge(Edge {
+            source: 904,
+            target: 1343,
+        });
+        gs.add_edge(Edge {
+            source: 1174,
+            target: 1343,
+        });
+        gs.add_edge(Edge {
+            source: 1295,
+            target: 1343,
+        });
+        gs.add_edge(Edge {
+            source: 1310,
+            target: 1343,
+        });
+        gs.add_edge(Edge {
+            source: 1334,
+            target: 1343,
+        });
+        gs.add_edge(Edge {
+            source: 1335,
+            target: 1343,
+        });
+        gs.add_edge(Edge {
+            source: 1336,
+            target: 1343,
+        });
+        gs.add_edge(Edge {
+            source: 1337,
+            target: 1343,
+        });
+        gs.add_edge(Edge {
+            source: 1338,
+            target: 1343,
+        });
+        gs.add_edge(Edge {
+            source: 1339,
+            target: 1343,
+        });
+        gs.add_edge(Edge {
+            source: 1340,
+            target: 1343,
+        });
+        gs.add_edge(Edge {
+            source: 1341,
+            target: 1343,
+        });
+        gs.add_edge(Edge {
+            source: 1342,
+            target: 1343,
+        });
+        gs.add_edge(Edge {
+            source: 1343,
+            target: 1343,
+        });
+        gs.add_edge(Edge {
+            source: 903,
+            target: 1342,
+        });
+        gs.add_edge(Edge {
+            source: 904,
+            target: 1342,
+        });
+        gs.add_edge(Edge {
+            source: 1174,
+            target: 1342,
+        });
+        gs.add_edge(Edge {
+            source: 1295,
+            target: 1342,
+        });
+        gs.add_edge(Edge {
+            source: 1310,
+            target: 1342,
+        });
+        gs.add_edge(Edge {
+            source: 1334,
+            target: 1342,
+        });
+        gs.add_edge(Edge {
+            source: 1335,
+            target: 1342,
+        });
+        gs.add_edge(Edge {
+            source: 1336,
+            target: 1342,
+        });
+        gs.add_edge(Edge {
+            source: 1337,
+            target: 1342,
+        });
+        gs.add_edge(Edge {
+            source: 1338,
+            target: 1342,
+        });
+        gs.add_edge(Edge {
+            source: 1339,
+            target: 1342,
+        });
+        gs.add_edge(Edge {
+            source: 1340,
+            target: 1342,
+        });
+        gs.add_edge(Edge {
+            source: 1341,
+            target: 1342,
+        });
+        gs.add_edge(Edge {
+            source: 1342,
+            target: 1342,
+        });
+        gs.add_edge(Edge {
+            source: 1343,
+            target: 1342,
+        });
+        gs.add_edge(Edge {
+            source: 903,
+            target: 1339,
+        });
+        gs.add_edge(Edge {
+            source: 904,
+            target: 1339,
+        });
+        gs.add_edge(Edge {
+            source: 1174,
+            target: 1339,
+        });
+        gs.add_edge(Edge {
+            source: 1295,
+            target: 1339,
+        });
+        gs.add_edge(Edge {
+            source: 1310,
+            target: 1339,
+        });
+        gs.add_edge(Edge {
+            source: 1334,
+            target: 1339,
+        });
+        gs.add_edge(Edge {
+            source: 1335,
+            target: 1339,
+        });
+        gs.add_edge(Edge {
+            source: 1336,
+            target: 1339,
+        });
+        gs.add_edge(Edge {
+            source: 1337,
+            target: 1339,
+        });
+        gs.add_edge(Edge {
+            source: 1338,
+            target: 1339,
+        });
+        gs.add_edge(Edge {
+            source: 1339,
+            target: 1339,
+        });
+        gs.add_edge(Edge {
+            source: 1340,
+            target: 1339,
+        });
+        gs.add_edge(Edge {
+            source: 1341,
+            target: 1339,
+        });
+        gs.add_edge(Edge {
+            source: 1342,
+            target: 1339,
+        });
+        gs.add_edge(Edge {
+            source: 1343,
+            target: 1339,
+        });
+        gs.add_edge(Edge {
+            source: 903,
+            target: 904,
+        });
+        gs.add_edge(Edge {
+            source: 904,
+            target: 904,
+        });
+        gs.add_edge(Edge {
+            source: 1174,
+            target: 904,
+        });
+        gs.add_edge(Edge {
+            source: 1295,
+            target: 904,
+        });
+        gs.add_edge(Edge {
+            source: 1310,
+            target: 904,
+        });
+        gs.add_edge(Edge {
+            source: 1334,
+            target: 904,
+        });
+        gs.add_edge(Edge {
+            source: 1335,
+            target: 904,
+        });
+        gs.add_edge(Edge {
+            source: 1336,
+            target: 904,
+        });
+        gs.add_edge(Edge {
+            source: 1337,
+            target: 904,
+        });
+        gs.add_edge(Edge {
+            source: 1338,
+            target: 904,
+        });
+        gs.add_edge(Edge {
+            source: 1339,
+            target: 904,
+        });
+        gs.add_edge(Edge {
+            source: 1340,
+            target: 904,
+        });
+        gs.add_edge(Edge {
+            source: 1341,
+            target: 904,
+        });
+        gs.add_edge(Edge {
+            source: 1342,
+            target: 904,
+        });
+        gs.add_edge(Edge {
+            source: 1343,
+            target: 904,
+        });
+        gs.add_edge(Edge {
+            source: 903,
+            target: 1336,
+        });
+        gs.add_edge(Edge {
+            source: 904,
+            target: 1336,
+        });
+        gs.add_edge(Edge {
+            source: 1174,
+            target: 1336,
+        });
+        gs.add_edge(Edge {
+            source: 1295,
+            target: 1336,
+        });
+        gs.add_edge(Edge {
+            source: 1310,
+            target: 1336,
+        });
+        gs.add_edge(Edge {
+            source: 1334,
+            target: 1336,
+        });
+        gs.add_edge(Edge {
+            source: 1335,
+            target: 1336,
+        });
+        gs.add_edge(Edge {
+            source: 1336,
+            target: 1336,
+        });
+        gs.add_edge(Edge {
+            source: 1337,
+            target: 1336,
+        });
+        gs.add_edge(Edge {
+            source: 1338,
+            target: 1336,
+        });
+        gs.add_edge(Edge {
+            source: 1339,
+            target: 1336,
+        });
+        gs.add_edge(Edge {
+            source: 1340,
+            target: 1336,
+        });
+        gs.add_edge(Edge {
+            source: 1341,
+            target: 1336,
+        });
+        gs.add_edge(Edge {
+            source: 1342,
+            target: 1336,
+        });
+        gs.add_edge(Edge {
+            source: 1343,
+            target: 1336,
+        });
+        gs.add_edge(Edge {
+            source: 903,
+            target: 1337,
+        });
+        gs.add_edge(Edge {
+            source: 904,
+            target: 1337,
+        });
+        gs.add_edge(Edge {
+            source: 1174,
+            target: 1337,
+        });
+        gs.add_edge(Edge {
+            source: 1295,
+            target: 1337,
+        });
+        gs.add_edge(Edge {
+            source: 1310,
+            target: 1337,
+        });
+        gs.add_edge(Edge {
+            source: 1334,
+            target: 1337,
+        });
+        gs.add_edge(Edge {
+            source: 1335,
+            target: 1337,
+        });
+        gs.add_edge(Edge {
+            source: 1336,
+            target: 1337,
+        });
+        gs.add_edge(Edge {
+            source: 1337,
+            target: 1337,
+        });
+        gs.add_edge(Edge {
+            source: 1338,
+            target: 1337,
+        });
+        gs.add_edge(Edge {
+            source: 1339,
+            target: 1337,
+        });
+        gs.add_edge(Edge {
+            source: 1340,
+            target: 1337,
+        });
+        gs.add_edge(Edge {
+            source: 1341,
+            target: 1337,
+        });
+        gs.add_edge(Edge {
+            source: 1342,
+            target: 1337,
+        });
+        gs.add_edge(Edge {
+            source: 1343,
+            target: 1337,
+        });
+        gs.add_edge(Edge {
+            source: 903,
+            target: 1335,
+        });
+        gs.add_edge(Edge {
+            source: 904,
+            target: 1335,
+        });
+        gs.add_edge(Edge {
+            source: 1174,
+            target: 1335,
+        });
+        gs.add_edge(Edge {
+            source: 1295,
+            target: 1335,
+        });
+        gs.add_edge(Edge {
+            source: 1310,
+            target: 1335,
+        });
+        gs.add_edge(Edge {
+            source: 1334,
+            target: 1335,
+        });
+        gs.add_edge(Edge {
+            source: 1335,
+            target: 1335,
+        });
+        gs.add_edge(Edge {
+            source: 1336,
+            target: 1335,
+        });
+        gs.add_edge(Edge {
+            source: 1337,
+            target: 1335,
+        });
+        gs.add_edge(Edge {
+            source: 1338,
+            target: 1335,
+        });
+        gs.add_edge(Edge {
+            source: 1339,
+            target: 1335,
+        });
+        gs.add_edge(Edge {
+            source: 1340,
+            target: 1335,
+        });
+        gs.add_edge(Edge {
+            source: 1341,
+            target: 1335,
+        });
+        gs.add_edge(Edge {
+            source: 1342,
+            target: 1335,
+        });
+        gs.add_edge(Edge {
+            source: 1343,
+            target: 1335,
+        });
+        gs.add_edge(Edge {
+            source: 903,
+            target: 1340,
+        });
+        gs.add_edge(Edge {
+            source: 904,
+            target: 1340,
+        });
+        gs.add_edge(Edge {
+            source: 1174,
+            target: 1340,
+        });
+        gs.add_edge(Edge {
+            source: 1295,
+            target: 1340,
+        });
+        gs.add_edge(Edge {
+            source: 1310,
+            target: 1340,
+        });
+        gs.add_edge(Edge {
+            source: 1334,
+            target: 1340,
+        });
+        gs.add_edge(Edge {
+            source: 1335,
+            target: 1340,
+        });
+        gs.add_edge(Edge {
+            source: 1336,
+            target: 1340,
+        });
+        gs.add_edge(Edge {
+            source: 1337,
+            target: 1340,
+        });
+        gs.add_edge(Edge {
+            source: 1338,
+            target: 1340,
+        });
+        gs.add_edge(Edge {
+            source: 1339,
+            target: 1340,
+        });
+        gs.add_edge(Edge {
+            source: 1340,
+            target: 1340,
+        });
+        gs.add_edge(Edge {
+            source: 1341,
+            target: 1340,
+        });
+        gs.add_edge(Edge {
+            source: 1342,
+            target: 1340,
+        });
+        gs.add_edge(Edge {
+            source: 1343,
+            target: 1340,
+        });
+        gs.add_edge(Edge {
+            source: 903,
+            target: 1338,
+        });
+        gs.add_edge(Edge {
+            source: 904,
+            target: 1338,
+        });
+        gs.add_edge(Edge {
+            source: 1174,
+            target: 1338,
+        });
+        gs.add_edge(Edge {
+            source: 1295,
+            target: 1338,
+        });
+        gs.add_edge(Edge {
+            source: 1310,
+            target: 1338,
+        });
+        gs.add_edge(Edge {
+            source: 1334,
+            target: 1338,
+        });
+        gs.add_edge(Edge {
+            source: 1335,
+            target: 1338,
+        });
+        gs.add_edge(Edge {
+            source: 1336,
+            target: 1338,
+        });
+        gs.add_edge(Edge {
+            source: 1337,
+            target: 1338,
+        });
+        gs.add_edge(Edge {
+            source: 1338,
+            target: 1338,
+        });
+        gs.add_edge(Edge {
+            source: 1339,
+            target: 1338,
+        });
+        gs.add_edge(Edge {
+            source: 1340,
+            target: 1338,
+        });
+        gs.add_edge(Edge {
+            source: 1341,
+            target: 1338,
+        });
+        gs.add_edge(Edge {
+            source: 1342,
+            target: 1338,
+        });
+        gs.add_edge(Edge {
+            source: 1343,
+            target: 1338,
+        });
+        gs.add_edge(Edge {
+            source: 903,
+            target: 1334,
+        });
+        gs.add_edge(Edge {
+            source: 904,
+            target: 1334,
+        });
+        gs.add_edge(Edge {
+            source: 1174,
+            target: 1334,
+        });
+        gs.add_edge(Edge {
+            source: 1295,
+            target: 1334,
+        });
+        gs.add_edge(Edge {
+            source: 1310,
+            target: 1334,
+        });
+        gs.add_edge(Edge {
+            source: 1334,
+            target: 1334,
+        });
+        gs.add_edge(Edge {
+            source: 1335,
+            target: 1334,
+        });
+        gs.add_edge(Edge {
+            source: 1336,
+            target: 1334,
+        });
+        gs.add_edge(Edge {
+            source: 1337,
+            target: 1334,
+        });
+        gs.add_edge(Edge {
+            source: 1338,
+            target: 1334,
+        });
+        gs.add_edge(Edge {
+            source: 1339,
+            target: 1334,
+        });
+        gs.add_edge(Edge {
+            source: 1340,
+            target: 1334,
+        });
+        gs.add_edge(Edge {
+            source: 1341,
+            target: 1334,
+        });
+        gs.add_edge(Edge {
+            source: 1342,
+            target: 1334,
+        });
+        gs.add_edge(Edge {
+            source: 1343,
+            target: 1334,
+        });
+        gs.add_edge(Edge {
+            source: 903,
+            target: 1341,
+        });
+        gs.add_edge(Edge {
+            source: 904,
+            target: 1341,
+        });
+        gs.add_edge(Edge {
+            source: 1174,
+            target: 1341,
+        });
+        gs.add_edge(Edge {
+            source: 1295,
+            target: 1341,
+        });
+        gs.add_edge(Edge {
+            source: 1310,
+            target: 1341,
+        });
+        gs.add_edge(Edge {
+            source: 1334,
+            target: 1341,
+        });
+        gs.add_edge(Edge {
+            source: 1335,
+            target: 1341,
+        });
+        gs.add_edge(Edge {
+            source: 1336,
+            target: 1341,
+        });
+        gs.add_edge(Edge {
+            source: 1337,
+            target: 1341,
+        });
+        gs.add_edge(Edge {
+            source: 1338,
+            target: 1341,
+        });
+        gs.add_edge(Edge {
+            source: 1339,
+            target: 1341,
+        });
+        gs.add_edge(Edge {
+            source: 1340,
+            target: 1341,
+        });
+        gs.add_edge(Edge {
+            source: 1341,
+            target: 1341,
+        });
+        gs.add_edge(Edge {
+            source: 1342,
+            target: 1341,
+        });
+        gs.add_edge(Edge {
+            source: 1343,
+            target: 1341,
+        });
+        gs.add_edge(Edge {
+            source: 905,
+            target: 946,
+        });
+        gs.add_edge(Edge {
+            source: 908,
+            target: 946,
+        });
+        gs.add_edge(Edge {
+            source: 909,
+            target: 946,
+        });
+        gs.add_edge(Edge {
+            source: 916,
+            target: 946,
+        });
+        gs.add_edge(Edge {
+            source: 942,
+            target: 946,
+        });
+        gs.add_edge(Edge {
+            source: 945,
+            target: 946,
+        });
+        gs.add_edge(Edge {
+            source: 946,
+            target: 946,
+        });
+        gs.add_edge(Edge {
+            source: 906,
+            target: 946,
+        });
+        gs.add_edge(Edge {
+            source: 934,
+            target: 946,
+        });
+        gs.add_edge(Edge {
+            source: 967,
+            target: 946,
+        });
+        gs.add_edge(Edge {
+            source: 990,
+            target: 946,
+        });
+        gs.add_edge(Edge {
+            source: 1062,
+            target: 946,
+        });
+        gs.add_edge(Edge {
+            source: 1177,
+            target: 946,
+        });
+        gs.add_edge(Edge {
+            source: 1263,
+            target: 946,
+        });
+        gs.add_edge(Edge {
+            source: 1266,
+            target: 946,
+        });
+        gs.add_edge(Edge {
+            source: 1291,
+            target: 946,
+        });
+        gs.add_edge(Edge {
+            source: 1294,
+            target: 946,
+        });
+        gs.add_edge(Edge {
+            source: 1296,
+            target: 946,
+        });
+        gs.add_edge(Edge {
+            source: 1311,
+            target: 946,
+        });
+        gs.add_edge(Edge {
+            source: 948,
+            target: 948,
+        });
+        gs.add_edge(Edge {
+            source: 951,
+            target: 954,
+        });
+        gs.add_edge(Edge {
+            source: 954,
+            target: 954,
+        });
+        gs.add_edge(Edge {
+            source: 1016,
+            target: 954,
+        });
+        gs.add_edge(Edge {
+            source: 944,
+            target: 944,
+        });
+        gs.add_edge(Edge {
+            source: 1081,
+            target: 1081,
+        });
+        gs.add_edge(Edge {
+            source: 957,
+            target: 962,
+        });
+        gs.add_edge(Edge {
+            source: 959,
+            target: 962,
+        });
+        gs.add_edge(Edge {
+            source: 962,
+            target: 962,
+        });
+        gs.add_edge(Edge {
+            source: 1126,
+            target: 962,
+        });
+        gs.add_edge(Edge {
+            source: 1306,
+            target: 962,
+        });
+        gs.add_edge(Edge {
+            source: 1326,
+            target: 962,
+        });
+        gs.add_edge(Edge {
+            source: 964,
+            target: 964,
+        });
+        gs.add_edge(Edge {
+            source: 965,
+            target: 965,
+        });
+        gs.add_edge(Edge {
+            source: 975,
+            target: 976,
+        });
+        gs.add_edge(Edge {
+            source: 976,
+            target: 976,
+        });
+        gs.add_edge(Edge {
+            source: 978,
+            target: 978,
+        });
+        gs.add_edge(Edge {
+            source: 980,
+            target: 982,
+        });
+        gs.add_edge(Edge {
+            source: 982,
+            target: 982,
+        });
+        gs.add_edge(Edge {
+            source: 983,
+            target: 983,
+        });
+        gs.add_edge(Edge {
+            source: 1083,
+            target: 1083,
+        });
+        gs.add_edge(Edge {
+            source: 912,
+            target: 912,
+        });
+        gs.add_edge(Edge {
+            source: 914,
+            target: 914,
+        });
+        gs.add_edge(Edge {
+            source: 1125,
+            target: 914,
+        });
+        gs.add_edge(Edge {
+            source: 933,
+            target: 935,
+        });
+        gs.add_edge(Edge {
+            source: 935,
+            target: 935,
+        });
+        gs.add_edge(Edge {
+            source: 963,
+            target: 935,
+        });
+        gs.add_edge(Edge {
+            source: 938,
+            target: 939,
+        });
+        gs.add_edge(Edge {
+            source: 939,
+            target: 939,
+        });
+        gs.add_edge(Edge {
+            source: 940,
+            target: 940,
+        });
+        gs.add_edge(Edge {
+            source: 941,
+            target: 941,
+        });
+        gs.add_edge(Edge {
+            source: 937,
+            target: 937,
+        });
+        gs.add_edge(Edge {
+            source: 924,
+            target: 926,
+        });
+        gs.add_edge(Edge {
+            source: 926,
+            target: 926,
+        });
+        gs.add_edge(Edge {
+            source: 927,
+            target: 927,
+        });
+        gs.add_edge(Edge {
+            source: 931,
+            target: 931,
+        });
+        gs.add_edge(Edge {
+            source: 922,
+            target: 922,
+        });
+        gs.add_edge(Edge {
+            source: 1086,
+            target: 1086,
+        });
+        gs.add_edge(Edge {
+            source: 987,
+            target: 993,
+        });
+        gs.add_edge(Edge {
+            source: 993,
+            target: 993,
+        });
+        gs.add_edge(Edge {
+            source: 1097,
+            target: 993,
+        });
+        gs.add_edge(Edge {
+            source: 1193,
+            target: 993,
+        });
+        gs.add_edge(Edge {
+            source: 1264,
+            target: 993,
+        });
+        gs.add_edge(Edge {
+            source: 1292,
+            target: 993,
+        });
+        gs.add_edge(Edge {
+            source: 1297,
+            target: 993,
+        });
+        gs.add_edge(Edge {
+            source: 1312,
+            target: 993,
+        });
+        gs.add_edge(Edge {
+            source: 994,
+            target: 994,
+        });
+        gs.add_edge(Edge {
+            source: 1265,
+            target: 994,
+        });
+        gs.add_edge(Edge {
+            source: 1293,
+            target: 994,
+        });
+        gs.add_edge(Edge {
+            source: 995,
+            target: 995,
+        });
+        gs.add_edge(Edge {
+            source: 998,
+            target: 999,
+        });
+        gs.add_edge(Edge {
+            source: 999,
+            target: 999,
+        });
+        gs.add_edge(Edge {
+            source: 1327,
+            target: 999,
+        });
+        gs.add_edge(Edge {
+            source: 1003,
+            target: 1003,
+        });
+        gs.add_edge(Edge {
+            source: 1004,
+            target: 950,
+        });
+        gs.add_edge(Edge {
+            source: 936,
+            target: 950,
+        });
+        gs.add_edge(Edge {
+            source: 950,
+            target: 950,
+        });
+        gs.add_edge(Edge {
+            source: 1010,
+            target: 952,
+        });
+        gs.add_edge(Edge {
+            source: 952,
+            target: 952,
+        });
+        gs.add_edge(Edge {
+            source: 953,
+            target: 953,
+        });
+        gs.add_edge(Edge {
+            source: 955,
+            target: 955,
+        });
+        gs.add_edge(Edge {
+            source: 956,
+            target: 956,
+        });
+        gs.add_edge(Edge {
+            source: 1040,
+            target: 956,
+        });
+        gs.add_edge(Edge {
+            source: 1019,
+            target: 1047,
+        });
+        gs.add_edge(Edge {
+            source: 1046,
+            target: 1047,
+        });
+        gs.add_edge(Edge {
+            source: 1047,
+            target: 1047,
+        });
+        gs.add_edge(Edge {
+            source: 1092,
+            target: 1047,
+        });
+        gs.add_edge(Edge {
+            source: 1048,
+            target: 1048,
+        });
+        gs.add_edge(Edge {
+            source: 1049,
+            target: 1050,
+        });
+        gs.add_edge(Edge {
+            source: 1050,
+            target: 1050,
+        });
+        gs.add_edge(Edge {
+            source: 1054,
+            target: 1000,
+        });
+        gs.add_edge(Edge {
+            source: 996,
+            target: 1000,
+        });
+        gs.add_edge(Edge {
+            source: 1000,
+            target: 1000,
+        });
+        gs.add_edge(Edge {
+            source: 1001,
+            target: 1001,
+        });
+        gs.add_edge(Edge {
+            source: 1002,
+            target: 1002,
+        });
+        gs.add_edge(Edge {
+            source: 1042,
+            target: 1042,
+        });
+        gs.add_edge(Edge {
+            source: 1078,
+            target: 1078,
+        });
+        gs.add_edge(Edge {
+            source: 919,
+            target: 1005,
+        });
+        gs.add_edge(Edge {
+            source: 1058,
+            target: 1005,
+        });
+        gs.add_edge(Edge {
+            source: 1068,
+            target: 1005,
+        });
+        gs.add_edge(Edge {
+            source: 1005,
+            target: 1005,
+        });
+        gs.add_edge(Edge {
+            source: 1167,
+            target: 1005,
+        });
+        gs.add_edge(Edge {
+            source: 1203,
+            target: 1005,
+        });
+        gs.add_edge(Edge {
+            source: 1298,
+            target: 1005,
+        });
+        gs.add_edge(Edge {
+            source: 1313,
+            target: 1005,
+        });
+        gs.add_edge(Edge {
+            source: 1007,
+            target: 1007,
+        });
+        gs.add_edge(Edge {
+            source: 1008,
+            target: 1008,
+        });
+        gs.add_edge(Edge {
+            source: 1015,
+            target: 1015,
+        });
+        gs.add_edge(Edge {
+            source: 1020,
+            target: 1020,
+        });
+        gs.add_edge(Edge {
+            source: 1071,
+            target: 1022,
+        });
+        gs.add_edge(Edge {
+            source: 1022,
+            target: 1022,
+        });
+        gs.add_edge(Edge {
+            source: 1073,
+            target: 918,
+        });
+        gs.add_edge(Edge {
+            source: 913,
+            target: 918,
+        });
+        gs.add_edge(Edge {
+            source: 918,
+            target: 918,
+        });
+        gs.add_edge(Edge {
+            source: 920,
+            target: 920,
+        });
+        gs.add_edge(Edge {
+            source: 921,
+            target: 921,
+        });
+        gs.add_edge(Edge {
+            source: 1076,
+            target: 923,
+        });
+        gs.add_edge(Edge {
+            source: 923,
+            target: 923,
+        });
+        gs.add_edge(Edge {
+            source: 1060,
+            target: 923,
+        });
+        gs.add_edge(Edge {
+            source: 928,
+            target: 928,
+        });
+        gs.add_edge(Edge {
+            source: 1023,
+            target: 1023,
+        });
+        gs.add_edge(Edge {
+            source: 1077,
+            target: 930,
+        });
+        gs.add_edge(Edge {
+            source: 1079,
+            target: 930,
+        });
+        gs.add_edge(Edge {
+            source: 930,
+            target: 930,
+        });
+        gs.add_edge(Edge {
+            source: 932,
+            target: 932,
+        });
+        gs.add_edge(Edge {
+            source: 1025,
+            target: 1025,
+        });
+        gs.add_edge(Edge {
+            source: 1026,
+            target: 1026,
+        });
+        gs.add_edge(Edge {
+            source: 1028,
+            target: 1028,
+        });
+        gs.add_edge(Edge {
+            source: 1029,
+            target: 1029,
+        });
+        gs.add_edge(Edge {
+            source: 1063,
+            target: 1030,
+        });
+        gs.add_edge(Edge {
+            source: 1030,
+            target: 1030,
+        });
+        gs.add_edge(Edge {
+            source: 1066,
+            target: 1031,
+        });
+        gs.add_edge(Edge {
+            source: 1031,
+            target: 1031,
+        });
+        gs.add_edge(Edge {
+            source: 1032,
+            target: 1032,
+        });
+        gs.add_edge(Edge {
+            source: 1033,
+            target: 1033,
+        });
+        gs.add_edge(Edge {
+            source: 1034,
+            target: 1034,
+        });
+        gs.add_edge(Edge {
+            source: 1035,
+            target: 1035,
+        });
+        gs.add_edge(Edge {
+            source: 925,
+            target: 1036,
+        });
+        gs.add_edge(Edge {
+            source: 1082,
+            target: 1036,
+        });
+        gs.add_edge(Edge {
+            source: 1084,
+            target: 1036,
+        });
+        gs.add_edge(Edge {
+            source: 1036,
+            target: 1036,
+        });
+        gs.add_edge(Edge {
+            source: 1129,
+            target: 1036,
+        });
+        gs.add_edge(Edge {
+            source: 1208,
+            target: 1036,
+        });
+        gs.add_edge(Edge {
+            source: 1299,
+            target: 1036,
+        });
+        gs.add_edge(Edge {
+            source: 1314,
+            target: 1036,
+        });
+        gs.add_edge(Edge {
+            source: 1328,
+            target: 1036,
+        });
+        gs.add_edge(Edge {
+            source: 1037,
+            target: 1037,
+        });
+        gs.add_edge(Edge {
+            source: 1088,
+            target: 1038,
+        });
+        gs.add_edge(Edge {
+            source: 1038,
+            target: 1038,
+        });
+        gs.add_edge(Edge {
+            source: 1039,
+            target: 1039,
+        });
+        gs.add_edge(Edge {
+            source: 1052,
+            target: 1039,
+        });
+        gs.add_edge(Edge {
+            source: 1043,
+            target: 1043,
+        });
+        gs.add_edge(Edge {
+            source: 1091,
+            target: 1053,
+        });
+        gs.add_edge(Edge {
+            source: 1053,
+            target: 1053,
+        });
+        gs.add_edge(Edge {
+            source: 1158,
+            target: 1053,
+        });
+        gs.add_edge(Edge {
+            source: 1095,
+            target: 1055,
+        });
+        gs.add_edge(Edge {
+            source: 1055,
+            target: 1055,
+        });
+        gs.add_edge(Edge {
+            source: 1056,
+            target: 1056,
+        });
+        gs.add_edge(Edge {
+            source: 1057,
+            target: 1057,
+        });
+        gs.add_edge(Edge {
+            source: 1059,
+            target: 1059,
+        });
+        gs.add_edge(Edge {
+            source: 1061,
+            target: 1061,
+        });
+        gs.add_edge(Edge {
+            source: 929,
+            target: 1090,
+        });
+        gs.add_edge(Edge {
+            source: 943,
+            target: 1090,
+        });
+        gs.add_edge(Edge {
+            source: 1099,
+            target: 1090,
+        });
+        gs.add_edge(Edge {
+            source: 1120,
+            target: 1090,
+        });
+        gs.add_edge(Edge {
+            source: 1122,
+            target: 1090,
+        });
+        gs.add_edge(Edge {
+            source: 1090,
+            target: 1090,
+        });
+        gs.add_edge(Edge {
+            source: 1209,
+            target: 1090,
+        });
+        gs.add_edge(Edge {
+            source: 1300,
+            target: 1090,
+        });
+        gs.add_edge(Edge {
+            source: 1315,
+            target: 1090,
+        });
+        gs.add_edge(Edge {
+            source: 1093,
+            target: 1093,
+        });
+        gs.add_edge(Edge {
+            source: 1094,
+            target: 1094,
+        });
+        gs.add_edge(Edge {
+            source: 1116,
+            target: 1067,
+        });
+        gs.add_edge(Edge {
+            source: 1065,
+            target: 1067,
+        });
+        gs.add_edge(Edge {
+            source: 1067,
+            target: 1067,
+        });
+        gs.add_edge(Edge {
+            source: 1329,
+            target: 1067,
+        });
+        gs.add_edge(Edge {
+            source: 1096,
+            target: 1096,
+        });
+        gs.add_edge(Edge {
+            source: 1069,
+            target: 1069,
+        });
+        gs.add_edge(Edge {
+            source: 1098,
+            target: 1098,
+        });
+        gs.add_edge(Edge {
+            source: 1124,
+            target: 1100,
+        });
+        gs.add_edge(Edge {
+            source: 1100,
+            target: 1100,
+        });
+        gs.add_edge(Edge {
+            source: 1101,
+            target: 1101,
+        });
+        gs.add_edge(Edge {
+            source: 1103,
+            target: 1103,
+        });
+        gs.add_edge(Edge {
+            source: 1105,
+            target: 1105,
+        });
+        gs.add_edge(Edge {
+            source: 907,
+            target: 1118,
+        });
+        gs.add_edge(Edge {
+            source: 947,
+            target: 1118,
+        });
+        gs.add_edge(Edge {
+            source: 1021,
+            target: 1118,
+        });
+        gs.add_edge(Edge {
+            source: 1041,
+            target: 1118,
+        });
+        gs.add_edge(Edge {
+            source: 1134,
+            target: 1118,
+        });
+        gs.add_edge(Edge {
+            source: 1149,
+            target: 1118,
+        });
+        gs.add_edge(Edge {
+            source: 1160,
+            target: 1118,
+        });
+        gs.add_edge(Edge {
+            source: 1182,
+            target: 1118,
+        });
+        gs.add_edge(Edge {
+            source: 1114,
+            target: 1118,
+        });
+        gs.add_edge(Edge {
+            source: 1118,
+            target: 1118,
+        });
+        gs.add_edge(Edge {
+            source: 1211,
+            target: 1118,
+        });
+        gs.add_edge(Edge {
+            source: 1224,
+            target: 1118,
+        });
+        gs.add_edge(Edge {
+            source: 1232,
+            target: 1118,
+        });
+        gs.add_edge(Edge {
+            source: 1267,
+            target: 1118,
+        });
+        gs.add_edge(Edge {
+            source: 1270,
+            target: 1118,
+        });
+        gs.add_edge(Edge {
+            source: 1301,
+            target: 1118,
+        });
+        gs.add_edge(Edge {
+            source: 1316,
+            target: 1118,
+        });
+        gs.add_edge(Edge {
+            source: 1121,
+            target: 1121,
+        });
+        gs.add_edge(Edge {
+            source: 1183,
+            target: 1024,
+        });
+        gs.add_edge(Edge {
+            source: 1018,
+            target: 1024,
+        });
+        gs.add_edge(Edge {
+            source: 1024,
+            target: 1024,
+        });
+        gs.add_edge(Edge {
+            source: 1148,
+            target: 1148,
+        });
+        gs.add_edge(Edge {
+            source: 1027,
+            target: 1027,
+        });
+        gs.add_edge(Edge {
+            source: 1152,
+            target: 1152,
+        });
+        gs.add_edge(Edge {
+            source: 1150,
+            target: 1150,
+        });
+        gs.add_edge(Edge {
+            source: 1151,
+            target: 1151,
+        });
+        gs.add_edge(Edge {
+            source: 1153,
+            target: 1153,
+        });
+        gs.add_edge(Edge {
+            source: 1154,
+            target: 1154,
+        });
+        gs.add_edge(Edge {
+            source: 1155,
+            target: 1155,
+        });
+        gs.add_edge(Edge {
+            source: 911,
+            target: 1127,
+        });
+        gs.add_edge(Edge {
+            source: 910,
+            target: 1127,
+        });
+        gs.add_edge(Edge {
+            source: 915,
+            target: 1127,
+        });
+        gs.add_edge(Edge {
+            source: 1127,
+            target: 1127,
+        });
+        gs.add_edge(Edge {
+            source: 1185,
+            target: 1127,
+        });
+        gs.add_edge(Edge {
+            source: 1189,
+            target: 1127,
+        });
+        gs.add_edge(Edge {
+            source: 1192,
+            target: 1127,
+        });
+        gs.add_edge(Edge {
+            source: 1227,
+            target: 1127,
+        });
+        gs.add_edge(Edge {
+            source: 1269,
+            target: 1127,
+        });
+        gs.add_edge(Edge {
+            source: 1302,
+            target: 1127,
+        });
+        gs.add_edge(Edge {
+            source: 1317,
+            target: 1127,
+        });
+        gs.add_edge(Edge {
+            source: 1321,
+            target: 1127,
+        });
+        gs.add_edge(Edge {
+            source: 1156,
+            target: 1156,
+        });
+        gs.add_edge(Edge {
+            source: 1128,
+            target: 1131,
+        });
+        gs.add_edge(Edge {
+            source: 1131,
+            target: 1131,
+        });
+        gs.add_edge(Edge {
+            source: 1011,
+            target: 1012,
+        });
+        gs.add_edge(Edge {
+            source: 1012,
+            target: 1012,
+        });
+        gs.add_edge(Edge {
+            source: 1013,
+            target: 1013,
+        });
+        gs.add_edge(Edge {
+            source: 1157,
+            target: 1157,
+        });
+        gs.add_edge(Edge {
+            source: 1159,
+            target: 1159,
+        });
+        gs.add_edge(Edge {
+            source: 1235,
+            target: 1159,
+        });
+        gs.add_edge(Edge {
+            source: 1245,
+            target: 1159,
+        });
+        gs.add_edge(Edge {
+            source: 1271,
+            target: 1159,
+        });
+        gs.add_edge(Edge {
+            source: 1274,
+            target: 1159,
+        });
+        gs.add_edge(Edge {
+            source: 1197,
+            target: 1161,
+        });
+        gs.add_edge(Edge {
+            source: 1161,
+            target: 1161,
+        });
+        gs.add_edge(Edge {
+            source: 1162,
+            target: 1162,
+        });
+        gs.add_edge(Edge {
+            source: 1226,
+            target: 1162,
+        });
+        gs.add_edge(Edge {
+            source: 1268,
+            target: 1162,
+        });
+        gs.add_edge(Edge {
+            source: 1200,
+            target: 1163,
+        });
+        gs.add_edge(Edge {
+            source: 1163,
+            target: 1163,
+        });
+        gs.add_edge(Edge {
+            source: 1164,
+            target: 1164,
+        });
+        gs.add_edge(Edge {
+            source: 1165,
+            target: 1165,
+        });
+        gs.add_edge(Edge {
+            source: 1166,
+            target: 1166,
+        });
+        gs.add_edge(Edge {
+            source: 917,
+            target: 1168,
+        });
+        gs.add_edge(Edge {
+            source: 1168,
+            target: 1168,
+        });
+        gs.add_edge(Edge {
+            source: 1240,
+            target: 1168,
+        });
+        gs.add_edge(Edge {
+            source: 1272,
+            target: 1168,
+        });
+        gs.add_edge(Edge {
+            source: 1322,
+            target: 1168,
+        });
+        gs.add_edge(Edge {
+            source: 1169,
+            target: 1169,
+        });
+        gs.add_edge(Edge {
+            source: 1242,
+            target: 1169,
+        });
+        gs.add_edge(Edge {
+            source: 1273,
+            target: 1169,
+        });
+        gs.add_edge(Edge {
+            source: 1202,
+            target: 1170,
+        });
+        gs.add_edge(Edge {
+            source: 1170,
+            target: 1170,
+        });
+        gs.add_edge(Edge {
+            source: 1171,
+            target: 1171,
+        });
+        gs.add_edge(Edge {
+            source: 1204,
+            target: 1172,
+        });
+        gs.add_edge(Edge {
+            source: 1172,
+            target: 1172,
+        });
+        gs.add_edge(Edge {
+            source: 1307,
+            target: 1172,
+        });
+        gs.add_edge(Edge {
+            source: 1205,
+            target: 1074,
+        });
+        gs.add_edge(Edge {
+            source: 1070,
+            target: 1074,
+        });
+        gs.add_edge(Edge {
+            source: 1074,
+            target: 1074,
+        });
+        gs.add_edge(Edge {
+            source: 1075,
+            target: 1075,
+        });
+        gs.add_edge(Edge {
+            source: 1080,
+            target: 1080,
+        });
+        gs.add_edge(Edge {
+            source: 1206,
+            target: 1085,
+        });
+        gs.add_edge(Edge {
+            source: 1085,
+            target: 1085,
+        });
+        gs.add_edge(Edge {
+            source: 1087,
+            target: 1087,
+        });
+        gs.add_edge(Edge {
+            source: 1089,
+            target: 1089,
+        });
+        gs.add_edge(Edge {
+            source: 1173,
+            target: 1173,
+        });
+        gs.add_edge(Edge {
+            source: 1175,
+            target: 1175,
+        });
+        gs.add_edge(Edge {
+            source: 1176,
+            target: 1176,
+        });
+        gs.add_edge(Edge {
+            source: 949,
+            target: 1106,
+        });
+        gs.add_edge(Edge {
+            source: 1207,
+            target: 1106,
+        });
+        gs.add_edge(Edge {
+            source: 1106,
+            target: 1106,
+        });
+        gs.add_edge(Edge {
+            source: 1123,
+            target: 1106,
+        });
+        gs.add_edge(Edge {
+            source: 1215,
+            target: 1106,
+        });
+        gs.add_edge(Edge {
+            source: 1247,
+            target: 1106,
+        });
+        gs.add_edge(Edge {
+            source: 1250,
+            target: 1106,
+        });
+        gs.add_edge(Edge {
+            source: 1251,
+            target: 1106,
+        });
+        gs.add_edge(Edge {
+            source: 1254,
+            target: 1106,
+        });
+        gs.add_edge(Edge {
+            source: 1275,
+            target: 1106,
+        });
+        gs.add_edge(Edge {
+            source: 1278,
+            target: 1106,
+        });
+        gs.add_edge(Edge {
+            source: 1279,
+            target: 1106,
+        });
+        gs.add_edge(Edge {
+            source: 1282,
+            target: 1106,
+        });
+        gs.add_edge(Edge {
+            source: 1303,
+            target: 1106,
+        });
+        gs.add_edge(Edge {
+            source: 1318,
+            target: 1106,
+        });
+        gs.add_edge(Edge {
+            source: 1330,
+            target: 1106,
+        });
+        gs.add_edge(Edge {
+            source: 1107,
+            target: 1107,
+        });
+        gs.add_edge(Edge {
+            source: 1210,
+            target: 1108,
+        });
+        gs.add_edge(Edge {
+            source: 1212,
+            target: 1108,
+        });
+        gs.add_edge(Edge {
+            source: 1108,
+            target: 1108,
+        });
+        gs.add_edge(Edge {
+            source: 1109,
+            target: 1109,
+        });
+        gs.add_edge(Edge {
+            source: 969,
+            target: 1115,
+        });
+        gs.add_edge(Edge {
+            source: 1213,
+            target: 1115,
+        });
+        gs.add_edge(Edge {
+            source: 1115,
+            target: 1115,
+        });
+        gs.add_edge(Edge {
+            source: 1248,
+            target: 1115,
+        });
+        gs.add_edge(Edge {
+            source: 1276,
+            target: 1115,
+        });
+        gs.add_edge(Edge {
+            source: 1323,
+            target: 1115,
+        });
+        gs.add_edge(Edge {
+            source: 1214,
+            target: 1117,
+        });
+        gs.add_edge(Edge {
+            source: 1216,
+            target: 1117,
+        });
+        gs.add_edge(Edge {
+            source: 1117,
+            target: 1117,
+        });
+        gs.add_edge(Edge {
+            source: 1249,
+            target: 1117,
+        });
+        gs.add_edge(Edge {
+            source: 1277,
+            target: 1117,
+        });
+        gs.add_edge(Edge {
+            source: 1119,
+            target: 1119,
+        });
+        gs.add_edge(Edge {
+            source: 1130,
+            target: 1130,
+        });
+        gs.add_edge(Edge {
+            source: 1132,
+            target: 1132,
+        });
+        gs.add_edge(Edge {
+            source: 1217,
+            target: 1133,
+        });
+        gs.add_edge(Edge {
+            source: 1133,
+            target: 1133,
+        });
+        gs.add_edge(Edge {
+            source: 1252,
+            target: 1133,
+        });
+        gs.add_edge(Edge {
+            source: 1280,
+            target: 1133,
+        });
+        gs.add_edge(Edge {
+            source: 1135,
+            target: 1135,
+        });
+        gs.add_edge(Edge {
+            source: 1253,
+            target: 1135,
+        });
+        gs.add_edge(Edge {
+            source: 1281,
+            target: 1135,
+        });
+        gs.add_edge(Edge {
+            source: 1136,
+            target: 1136,
+        });
+        gs.add_edge(Edge {
+            source: 1137,
+            target: 1137,
+        });
+        gs.add_edge(Edge {
+            source: 1138,
+            target: 1138,
+        });
+        gs.add_edge(Edge {
+            source: 1219,
+            target: 1139,
+        });
+        gs.add_edge(Edge {
+            source: 1139,
+            target: 1139,
+        });
+        gs.add_edge(Edge {
+            source: 1308,
+            target: 1139,
+        });
+        gs.add_edge(Edge {
+            source: 1220,
+            target: 1104,
+        });
+        gs.add_edge(Edge {
+            source: 1102,
+            target: 1104,
+        });
+        gs.add_edge(Edge {
+            source: 1104,
+            target: 1104,
+        });
+        gs.add_edge(Edge {
+            source: 1110,
+            target: 1110,
+        });
+        gs.add_edge(Edge {
+            source: 1111,
+            target: 1111,
+        });
+        gs.add_edge(Edge {
+            source: 1112,
+            target: 1112,
+        });
+        gs.add_edge(Edge {
+            source: 1113,
+            target: 1113,
+        });
+        gs.add_edge(Edge {
+            source: 1221,
+            target: 1140,
+        });
+        gs.add_edge(Edge {
+            source: 1140,
+            target: 1140,
+        });
+        gs.add_edge(Edge {
+            source: 1141,
+            target: 1141,
+        });
+        gs.add_edge(Edge {
+            source: 1142,
+            target: 1142,
+        });
+        gs.add_edge(Edge {
+            source: 1143,
+            target: 1143,
+        });
+        gs.add_edge(Edge {
+            source: 1144,
+            target: 1144,
+        });
+        gs.add_edge(Edge {
+            source: 1145,
+            target: 1145,
+        });
+        gs.add_edge(Edge {
+            source: 1146,
+            target: 1146,
+        });
+        gs.add_edge(Edge {
+            source: 1147,
+            target: 1147,
+        });
+        gs.add_edge(Edge {
+            source: 988,
+            target: 1178,
+        });
+        gs.add_edge(Edge {
+            source: 997,
+            target: 1178,
+        });
+        gs.add_edge(Edge {
+            source: 1051,
+            target: 1178,
+        });
+        gs.add_edge(Edge {
+            source: 1064,
+            target: 1178,
+        });
+        gs.add_edge(Edge {
+            source: 1223,
+            target: 1178,
+        });
+        gs.add_edge(Edge {
+            source: 1178,
+            target: 1178,
+        });
+        gs.add_edge(Edge {
+            source: 1218,
+            target: 1178,
+        });
+        gs.add_edge(Edge {
+            source: 1255,
+            target: 1178,
+        });
+        gs.add_edge(Edge {
+            source: 1258,
+            target: 1178,
+        });
+        gs.add_edge(Edge {
+            source: 1283,
+            target: 1178,
+        });
+        gs.add_edge(Edge {
+            source: 1286,
+            target: 1178,
+        });
+        gs.add_edge(Edge {
+            source: 1304,
+            target: 1178,
+        });
+        gs.add_edge(Edge {
+            source: 1319,
+            target: 1178,
+        });
+        gs.add_edge(Edge {
+            source: 1179,
+            target: 1179,
+        });
+        gs.add_edge(Edge {
+            source: 1225,
+            target: 968,
+        });
+        gs.add_edge(Edge {
+            source: 966,
+            target: 968,
+        });
+        gs.add_edge(Edge {
+            source: 968,
+            target: 968,
+        });
+        gs.add_edge(Edge {
+            source: 970,
+            target: 970,
+        });
+        gs.add_edge(Edge {
+            source: 1180,
+            target: 1180,
+        });
+        gs.add_edge(Edge {
+            source: 1181,
+            target: 1181,
+        });
+        gs.add_edge(Edge {
+            source: 1006,
+            target: 971,
+        });
+        gs.add_edge(Edge {
+            source: 1228,
+            target: 971,
+        });
+        gs.add_edge(Edge {
+            source: 1229,
+            target: 971,
+        });
+        gs.add_edge(Edge {
+            source: 971,
+            target: 971,
+        });
+        gs.add_edge(Edge {
+            source: 972,
+            target: 972,
+        });
+        gs.add_edge(Edge {
+            source: 1230,
+            target: 973,
+        });
+        gs.add_edge(Edge {
+            source: 973,
+            target: 973,
+        });
+        gs.add_edge(Edge {
+            source: 1257,
+            target: 973,
+        });
+        gs.add_edge(Edge {
+            source: 1285,
+            target: 973,
+        });
+        gs.add_edge(Edge {
+            source: 974,
+            target: 974,
+        });
+        gs.add_edge(Edge {
+            source: 1231,
+            target: 960,
+        });
+        gs.add_edge(Edge {
+            source: 1233,
+            target: 960,
+        });
+        gs.add_edge(Edge {
+            source: 1234,
+            target: 960,
+        });
+        gs.add_edge(Edge {
+            source: 958,
+            target: 960,
+        });
+        gs.add_edge(Edge {
+            source: 960,
+            target: 960,
+        });
+        gs.add_edge(Edge {
+            source: 961,
+            target: 961,
+        });
+        gs.add_edge(Edge {
+            source: 977,
+            target: 977,
+        });
+        gs.add_edge(Edge {
+            source: 979,
+            target: 979,
+        });
+        gs.add_edge(Edge {
+            source: 981,
+            target: 981,
+        });
+        gs.add_edge(Edge {
+            source: 1184,
+            target: 1184,
+        });
+        gs.add_edge(Edge {
+            source: 1009,
+            target: 984,
+        });
+        gs.add_edge(Edge {
+            source: 1236,
+            target: 984,
+        });
+        gs.add_edge(Edge {
+            source: 984,
+            target: 984,
+        });
+        gs.add_edge(Edge {
+            source: 1256,
+            target: 984,
+        });
+        gs.add_edge(Edge {
+            source: 1284,
+            target: 984,
+        });
+        gs.add_edge(Edge {
+            source: 1309,
+            target: 984,
+        });
+        gs.add_edge(Edge {
+            source: 1325,
+            target: 984,
+        });
+        gs.add_edge(Edge {
+            source: 1238,
+            target: 985,
+        });
+        gs.add_edge(Edge {
+            source: 985,
+            target: 985,
+        });
+        gs.add_edge(Edge {
+            source: 1239,
+            target: 986,
+        });
+        gs.add_edge(Edge {
+            source: 986,
+            target: 986,
+        });
+        gs.add_edge(Edge {
+            source: 1331,
+            target: 986,
+        });
+        gs.add_edge(Edge {
+            source: 989,
+            target: 989,
+        });
+        gs.add_edge(Edge {
+            source: 1237,
+            target: 991,
+        });
+        gs.add_edge(Edge {
+            source: 991,
+            target: 991,
+        });
+        gs.add_edge(Edge {
+            source: 992,
+            target: 992,
+        });
+        gs.add_edge(Edge {
+            source: 1186,
+            target: 1186,
+        });
+        gs.add_edge(Edge {
+            source: 1014,
+            target: 1045,
+        });
+        gs.add_edge(Edge {
+            source: 1072,
+            target: 1045,
+        });
+        gs.add_edge(Edge {
+            source: 1241,
+            target: 1045,
+        });
+        gs.add_edge(Edge {
+            source: 1044,
+            target: 1045,
+        });
+        gs.add_edge(Edge {
+            source: 1045,
+            target: 1045,
+        });
+        gs.add_edge(Edge {
+            source: 1222,
+            target: 1045,
+        });
+        gs.add_edge(Edge {
+            source: 1259,
+            target: 1045,
+        });
+        gs.add_edge(Edge {
+            source: 1262,
+            target: 1045,
+        });
+        gs.add_edge(Edge {
+            source: 1287,
+            target: 1045,
+        });
+        gs.add_edge(Edge {
+            source: 1290,
+            target: 1045,
+        });
+        gs.add_edge(Edge {
+            source: 1305,
+            target: 1045,
+        });
+        gs.add_edge(Edge {
+            source: 1320,
+            target: 1045,
+        });
+        gs.add_edge(Edge {
+            source: 1332,
+            target: 1045,
+        });
+        gs.add_edge(Edge {
+            source: 1187,
+            target: 1187,
+        });
+        gs.add_edge(Edge {
+            source: 1188,
+            target: 1188,
+        });
+        gs.add_edge(Edge {
+            source: 1190,
+            target: 1190,
+        });
+        gs.add_edge(Edge {
+            source: 1017,
+            target: 1191,
+        });
+        gs.add_edge(Edge {
+            source: 1243,
+            target: 1191,
+        });
+        gs.add_edge(Edge {
+            source: 1191,
+            target: 1191,
+        });
+        gs.add_edge(Edge {
+            source: 1260,
+            target: 1191,
+        });
+        gs.add_edge(Edge {
+            source: 1288,
+            target: 1191,
+        });
+        gs.add_edge(Edge {
+            source: 1324,
+            target: 1191,
+        });
+        gs.add_edge(Edge {
+            source: 1244,
+            target: 1194,
+        });
+        gs.add_edge(Edge {
+            source: 1194,
+            target: 1194,
+        });
+        gs.add_edge(Edge {
+            source: 1261,
+            target: 1194,
+        });
+        gs.add_edge(Edge {
+            source: 1289,
+            target: 1194,
+        });
+        gs.add_edge(Edge {
+            source: 1333,
+            target: 1194,
+        });
+        gs.add_edge(Edge {
+            source: 1195,
+            target: 1195,
+        });
+        gs.add_edge(Edge {
+            source: 1246,
+            target: 1196,
+        });
+        gs.add_edge(Edge {
+            source: 1196,
+            target: 1196,
+        });
+        gs.add_edge(Edge {
+            source: 1198,
+            target: 1198,
+        });
+        gs.add_edge(Edge {
+            source: 1199,
+            target: 1199,
+        });
+        gs.add_edge(Edge {
+            source: 1201,
+            target: 1201,
         });
 
         gs.calculate_statistics();

--- a/src/annis/db/relannis.rs
+++ b/src/annis/db/relannis.rs
@@ -575,14 +575,20 @@ where
                 Arc::make_mut(&mut db.node_annos).insert(node_nr, layer_anno);
             }
 
-            let left_val = line.get(5).ok_or("Missing column")?.parse::<u32>()?;
+            // Use left/right token columns for relANNIS 3.3 and the left/right character column otherwise.
+            // For some malformed corpora, the token coverage information is more robust and guaranties that a node is
+            // only left/right aligned to a single token.
+            let left_column = if is_annis_33 {8} else {5};
+            let right_column = if is_annis_33 {9} else {6};
+
+            let left_val = line.get(left_column).ok_or("Missing column")?.parse::<u32>()?;
             let left = TextProperty {
                 segmentation: String::from(""),
                 val: left_val,
                 corpus_id,
                 text_id,
             };
-            let right_val = line.get(6).ok_or("Missing column")?.parse::<u32>()?;
+            let right_val = line.get(right_column).ok_or("Missing column")?.parse::<u32>()?;
             let right = TextProperty {
                 segmentation: String::from(""),
                 val: right_val,

--- a/src/annis/dfs.rs
+++ b/src/annis/dfs.rs
@@ -94,6 +94,8 @@ impl<'a> CycleSafeDFS<'a> {
             trace!("cycle detected for node {} with distance {}", &node, dist);
             self.last_distance = dist;
             self.cycle_detected = true;
+            trace!("removing from stack");
+            self.stack.pop();
             false
         } else {
             self.path.push(node);

--- a/src/annis/dfs.rs
+++ b/src/annis/dfs.rs
@@ -94,7 +94,7 @@ impl<'a> CycleSafeDFS<'a> {
             trace!("cycle detected for node {} with distance {}", &node, dist);
             self.last_distance = dist;
             self.cycle_detected = true;
-            trace!("removing from stack");
+            trace!("removing from stack because of cycle");
             self.stack.pop();
             false
         } else {


### PR DESCRIPTION
This fixes and issue with the cycle detection in the DFS and uses the left/right token columns instead of the text columns (when available) to calculate token alignment.

Fixes #48 