### PR TITLE
Implement ":arity" (number of outgoing edges) unary operator

### DIFF
--- a/src/annis/db/aql/ast.rs
+++ b/src/annis/db/aql/ast.rs
@@ -3,8 +3,9 @@ use std;
 use std::rc::Rc;
 
 use crate::annis::db::aql::operators::{
-    DominanceSpec, IdenticalCoverageSpec, IdenticalNodeSpec, InclusionSpec, OverlapSpec,
-    PartOfSubCorpusSpec, PointingSpec, PrecedenceSpec, LeftAlignmentSpec, RightAlignmentSpec,
+    AritySpec, DominanceSpec, IdenticalCoverageSpec, IdenticalNodeSpec, InclusionSpec,
+    LeftAlignmentSpec, OverlapSpec, PartOfSubCorpusSpec, PointingSpec, PrecedenceSpec,
+    RightAlignmentSpec,
 };
 use crate::annis::db::exec::nodesearch::NodeSearchSpec;
 
@@ -42,6 +43,11 @@ pub enum Literal {
         lhs: Operand,
         op: BinaryOpSpec,
         rhs: Operand,
+        pos: Option<Pos>,
+    },
+    UnaryOp {
+        node_ref: NodeRef,
+        op: UnaryOpSpec,
         pos: Option<Pos>,
     },
     LegacyMetaSearch {
@@ -95,6 +101,11 @@ pub enum BinaryOpSpec {
     LeftAlignment(LeftAlignmentSpec),
     RightAlignment(RightAlignmentSpec),
     IdenticalNode(IdenticalNodeSpec),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum UnaryOpSpec {
+    Arity(AritySpec),
 }
 
 pub use crate::annis::db::aql::operators::RangeSpec;

--- a/src/annis/db/aql/mod.rs
+++ b/src/annis/db/aql/mod.rs
@@ -13,7 +13,7 @@ use crate::annis::db::exec::nodesearch::NodeSearchSpec;
 use crate::annis::db::query::conjunction::Conjunction;
 use crate::annis::db::query::disjunction::Disjunction;
 use crate::annis::errors::*;
-use crate::annis::operator::OperatorSpec;
+use crate::annis::operator::BinaryOperatorSpec;
 use crate::annis::types::{LineColumn, LineColumnRange};
 use lalrpop_util::ParseError;
 use std::collections::BTreeMap;
@@ -332,7 +332,7 @@ pub fn parse<'a>(query_as_aql: &str, quirks_mode: bool) -> Result<Disjunction<'a
     }
 }
 
-fn make_operator_spec(op: ast::BinaryOpSpec) -> Box<OperatorSpec> {
+fn make_operator_spec(op: ast::BinaryOpSpec) -> Box<BinaryOperatorSpec> {
     match op {
         ast::BinaryOpSpec::Dominance(spec) => Box::new(spec),
         ast::BinaryOpSpec::Pointing(spec) => Box::new(spec),

--- a/src/annis/db/aql/mod.rs
+++ b/src/annis/db/aql/mod.rs
@@ -6,8 +6,8 @@ lalrpop_mod!(
     parser
 );
 
-use crate::annis::db::aql::operators::edge_op::PartOfSubCorpusSpec;
-use crate::annis::db::aql::operators::identical_node::IdenticalNodeSpec;
+use crate::annis::db::aql::operators::PartOfSubCorpusSpec;
+use crate::annis::db::aql::operators::IdenticalNodeSpec;
 use crate::annis::db::aql::operators::RangeSpec;
 use crate::annis::db::exec::nodesearch::NodeSearchSpec;
 use crate::annis::db::query::conjunction::Conjunction;

--- a/src/annis/db/aql/operators/arity.rs
+++ b/src/annis/db/aql/operators/arity.rs
@@ -1,6 +1,61 @@
 use super::RangeSpec;
+use crate::annis::operator::UnaryOperatorSpec;
+use crate::graph::{ComponentType, Component, Match, NodeID};
+use crate::Graph;
 
-#[derive(Debug)]
-pub struct Arity {
-    pub number: RangeSpec,
+use std;
+use rustc_hash::FxHashSet;
+
+#[derive(Debug, Clone)]
+pub struct AritySpec {
+    pub children: RangeSpec,
+}
+
+
+impl UnaryOperatorSpec for AritySpec {
+    fn necessary_components(&self, db: &Graph) -> Vec<Component> {
+        let mut result = Vec::default();
+        result.extend(db.get_all_components(Some(ComponentType::Dominance), None));
+        result.extend(db.get_all_components(Some(ComponentType::Coverage), None));
+        result
+    }
+    fn create_filter(&self, db: &Graph) -> Box<Fn(&Match) -> bool> {
+        // collect all relevant graph storages
+        let mut graphstorages = Vec::default();
+
+        for component in db.get_all_components(Some(ComponentType::Dominance), None) {
+            if let Some(gs) = db.get_graphstorage(&component) {
+                graphstorages.push(gs);
+            }
+        }
+        for component in db.get_all_components(Some(ComponentType::Coverage), None) {
+            if let Some(gs) = db.get_graphstorage(&component) {
+                graphstorages.push(gs);
+            }
+        }
+
+        let allowed_range = self.children.clone();
+
+        // create the filter which collects all child-nodes in all graphstorages
+        let filter = move |m : &Match| -> bool {
+            let mut children : FxHashSet<NodeID> = FxHashSet::default();
+            for gs in graphstorages.iter() {
+                for out in gs.get_outgoing_edges(m.node) {
+                    children.insert(out);
+                }
+            }
+
+            let num_children = children.len();
+            if num_children >= allowed_range.min_dist() {
+                match allowed_range.max_dist() {
+                    std::ops::Bound::Unbounded => true,
+                    std::ops::Bound::Included(max_dist) => num_children <= max_dist,
+                    std::ops::Bound::Excluded(max_dist) => num_children < max_dist,
+                }
+            } else {
+                false
+            }
+        };
+        Box::new(filter)
+    }
 }

--- a/src/annis/db/aql/operators/arity.rs
+++ b/src/annis/db/aql/operators/arity.rs
@@ -47,6 +47,12 @@ struct ArityOperator {
     allowed_range: RangeSpec,
 }
 
+impl std::fmt::Display for ArityOperator {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, ":arity={}", self.allowed_range)
+    }
+}
+
 
 impl UnaryOperator for ArityOperator {
 

--- a/src/annis/db/aql/operators/arity.rs
+++ b/src/annis/db/aql/operators/arity.rs
@@ -17,7 +17,7 @@ impl UnaryOperatorSpec for AritySpec {
     fn necessary_components(&self, db: &Graph) -> Vec<Component> {
         let mut result = Vec::default();
         result.extend(db.get_all_components(Some(ComponentType::Dominance), None));
-        result.extend(db.get_all_components(Some(ComponentType::Coverage), None));
+        result.extend(db.get_all_components(Some(ComponentType::Pointing), None));
         result
     }
     fn create_operator(&self, db: &Graph) -> Option<Box<UnaryOperator>> {
@@ -29,7 +29,7 @@ impl UnaryOperatorSpec for AritySpec {
                 graphstorages.push(gs);
             }
         }
-        for component in db.get_all_components(Some(ComponentType::Coverage), None) {
+        for component in db.get_all_components(Some(ComponentType::Pointing), None) {
             if let Some(gs) = db.get_graphstorage(&component) {
                 graphstorages.push(gs);
             }

--- a/src/annis/db/aql/operators/arity.rs
+++ b/src/annis/db/aql/operators/arity.rs
@@ -6,7 +6,7 @@ use crate::Graph;
 use std;
 use rustc_hash::FxHashSet;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct AritySpec {
     pub children: RangeSpec,
 }

--- a/src/annis/db/aql/operators/arity.rs
+++ b/src/annis/db/aql/operators/arity.rs
@@ -1,0 +1,6 @@
+use super::RangeSpec;
+
+#[derive(Debug)]
+pub struct Arity {
+    pub number: RangeSpec,
+}

--- a/src/annis/db/aql/operators/edge_op.rs
+++ b/src/annis/db/aql/operators/edge_op.rs
@@ -3,7 +3,7 @@ use crate::annis::db::aql::operators::RangeSpec;
 use crate::annis::db::graphstorage::{GraphStatistic, GraphStorage};
 use crate::annis::db::AnnotationStorage;
 use crate::annis::db::{Graph, Match, ANNIS_NS};
-use crate::annis::operator::{EdgeAnnoSearchSpec, EstimationType, Operator, OperatorSpec};
+use crate::annis::operator::{EdgeAnnoSearchSpec, EstimationType, BinaryOperator, BinaryOperatorSpec};
 use crate::annis::types::{AnnoKey, AnnoKeyID, Component, ComponentType, Edge, NodeID};
 use crate::annis::util;
 use regex;
@@ -44,12 +44,12 @@ impl BaseEdgeOp {
     }
 }
 
-impl OperatorSpec for BaseEdgeOpSpec {
+impl BinaryOperatorSpec for BaseEdgeOpSpec {
     fn necessary_components(&self, _db: &Graph) -> Vec<Component> {
         self.components.clone()
     }
 
-    fn create_operator(&self, db: &Graph) -> Option<Box<Operator>> {
+    fn create_operator(&self, db: &Graph) -> Option<Box<BinaryOperator>> {
         let optional_op = BaseEdgeOp::new(db, self.clone());
         if let Some(op) = optional_op {
             return Some(Box::new(op));
@@ -195,7 +195,7 @@ impl std::fmt::Display for BaseEdgeOp {
     }
 }
 
-impl Operator for BaseEdgeOp {
+impl BinaryOperator for BaseEdgeOp {
     fn retrieve_matches(&self, lhs: &Match) -> Box<Iterator<Item = Match>> {
         let lhs = lhs.clone();
         let spec = self.spec.clone();
@@ -321,7 +321,7 @@ impl Operator for BaseEdgeOp {
         self.spec.is_reflexive
     }
 
-    fn get_inverse_operator(&self) -> Option<Box<Operator>> {
+    fn get_inverse_operator(&self) -> Option<Box<BinaryOperator>> {
         // Check if all graph storages have the same inverse cost.
         // If not, we don't provide an inverse operator, because the plans would not account for the different costs
         for g in &self.gs {
@@ -459,12 +459,12 @@ pub struct DominanceSpec {
     pub edge_anno: Option<EdgeAnnoSearchSpec>,
 }
 
-impl OperatorSpec for DominanceSpec {
+impl BinaryOperatorSpec for DominanceSpec {
     fn necessary_components(&self, db: &Graph) -> Vec<Component> {
         db.get_all_components(Some(ComponentType::Dominance), Some(&self.name))
     }
 
-    fn create_operator(&self, db: &Graph) -> Option<Box<Operator>> {
+    fn create_operator(&self, db: &Graph) -> Option<Box<BinaryOperator>> {
         let components = db.get_all_components(Some(ComponentType::Dominance), Some(&self.name));
         let op_str = if self.name.is_empty() {
             String::from(">")
@@ -489,12 +489,12 @@ pub struct PointingSpec {
     pub edge_anno: Option<EdgeAnnoSearchSpec>,
 }
 
-impl OperatorSpec for PointingSpec {
+impl BinaryOperatorSpec for PointingSpec {
     fn necessary_components(&self, db: &Graph) -> Vec<Component> {
         db.get_all_components(Some(ComponentType::Pointing), Some(&self.name))
     }
 
-    fn create_operator(&self, db: &Graph) -> Option<Box<Operator>> {
+    fn create_operator(&self, db: &Graph) -> Option<Box<BinaryOperator>> {
         let components = db.get_all_components(Some(ComponentType::Pointing), Some(&self.name));
         let op_str = if self.name.is_empty() {
             String::from("->")
@@ -518,7 +518,7 @@ pub struct PartOfSubCorpusSpec {
     pub dist: RangeSpec,
 }
 
-impl OperatorSpec for PartOfSubCorpusSpec {
+impl BinaryOperatorSpec for PartOfSubCorpusSpec {
     fn necessary_components(&self, _db: &Graph) -> Vec<Component> {
         let components = vec![Component {
             ctype: ComponentType::PartOfSubcorpus,
@@ -528,7 +528,7 @@ impl OperatorSpec for PartOfSubCorpusSpec {
         components
     }
 
-    fn create_operator(&self, db: &Graph) -> Option<Box<Operator>> {
+    fn create_operator(&self, db: &Graph) -> Option<Box<BinaryOperator>> {
         let components = vec![Component {
             ctype: ComponentType::PartOfSubcorpus,
             layer: String::from(ANNIS_NS),

--- a/src/annis/db/aql/operators/identical_cov.rs
+++ b/src/annis/db/aql/operators/identical_cov.rs
@@ -3,7 +3,7 @@ use crate::annis::db::token_helper;
 use crate::annis::db::token_helper::TokenHelper;
 use crate::annis::db::{Graph, Match};
 use crate::annis::operator::EstimationType;
-use crate::annis::operator::{Operator, OperatorSpec};
+use crate::annis::operator::{BinaryOperator, BinaryOperatorSpec};
 use crate::annis::types::{AnnoKeyID, Component, ComponentType};
 
 use std;
@@ -36,14 +36,14 @@ lazy_static! {
     };
 }
 
-impl OperatorSpec for IdenticalCoverageSpec {
+impl BinaryOperatorSpec for IdenticalCoverageSpec {
     fn necessary_components(&self, _db: &Graph) -> Vec<Component> {
         let mut v: Vec<Component> = vec![COMPONENT_LEFT.clone(), COMPONENT_ORDER.clone()];
         v.append(&mut token_helper::necessary_components());
         v
     }
 
-    fn create_operator(&self, db: &Graph) -> Option<Box<Operator>> {
+    fn create_operator(&self, db: &Graph) -> Option<Box<BinaryOperator>> {
         let optional_op = IdenticalCoverage::new(db);
         if let Some(op) = optional_op {
             return Some(Box::new(op));
@@ -73,7 +73,7 @@ impl std::fmt::Display for IdenticalCoverage {
     }
 }
 
-impl Operator for IdenticalCoverage {
+impl BinaryOperator for IdenticalCoverage {
     fn retrieve_matches(&self, lhs: &Match) -> Box<Iterator<Item = Match>> {
         let n_left = self.tok_helper.left_token_for(lhs.node);
         let n_right = self.tok_helper.right_token_for(lhs.node);
@@ -128,7 +128,7 @@ impl Operator for IdenticalCoverage {
         false
     }
 
-    fn get_inverse_operator(&self) -> Option<Box<Operator>> {
+    fn get_inverse_operator(&self) -> Option<Box<BinaryOperator>> {
         Some(Box::new(self.clone()))
     }
 

--- a/src/annis/db/aql/operators/identical_node.rs
+++ b/src/annis/db/aql/operators/identical_node.rs
@@ -6,12 +6,12 @@ use std;
 #[derive(Debug, Clone, PartialOrd, Ord, Hash, PartialEq, Eq)]
 pub struct IdenticalNodeSpec;
 
-impl OperatorSpec for IdenticalNodeSpec {
+impl BinaryOperatorSpec for IdenticalNodeSpec {
     fn necessary_components(&self, _db: &Graph) -> Vec<Component> {
         vec![]
     }
 
-    fn create_operator(&self, _db: &Graph) -> Option<Box<Operator>> {
+    fn create_operator(&self, _db: &Graph) -> Option<Box<BinaryOperator>> {
         Some(Box::new(IdenticalNode {}))
     }
 }
@@ -25,7 +25,7 @@ impl std::fmt::Display for IdenticalNode {
     }
 }
 
-impl Operator for IdenticalNode {
+impl BinaryOperator for IdenticalNode {
     fn retrieve_matches(&self, lhs: &Match) -> Box<Iterator<Item = Match>> {
         Box::new(std::iter::once(Match {
             node: lhs.node,
@@ -41,7 +41,7 @@ impl Operator for IdenticalNode {
         EstimationType::MIN
     }
 
-    fn get_inverse_operator(&self) -> Option<Box<Operator>> {
+    fn get_inverse_operator(&self) -> Option<Box<BinaryOperator>> {
         Some(Box::new(self.clone()))
     }
 }

--- a/src/annis/db/aql/operators/inclusion.rs
+++ b/src/annis/db/aql/operators/inclusion.rs
@@ -3,7 +3,7 @@ use crate::annis::db::token_helper;
 use crate::annis::db::token_helper::TokenHelper;
 use crate::annis::db::{Graph, Match};
 use crate::annis::operator::EstimationType;
-use crate::annis::operator::{Operator, OperatorSpec};
+use crate::annis::operator::{BinaryOperator, BinaryOperatorSpec};
 use crate::annis::types::{AnnoKeyID, Component, ComponentType};
 
 use std;
@@ -53,7 +53,7 @@ lazy_static! {
     };
 }
 
-impl OperatorSpec for InclusionSpec {
+impl BinaryOperatorSpec for InclusionSpec {
     fn necessary_components(&self, _db: &Graph) -> Vec<Component> {
         let mut v: Vec<Component> = vec![
             COMPONENT_ORDER.clone(),
@@ -65,7 +65,7 @@ impl OperatorSpec for InclusionSpec {
         v
     }
 
-    fn create_operator(&self, db: &Graph) -> Option<Box<Operator>> {
+    fn create_operator(&self, db: &Graph) -> Option<Box<BinaryOperator>> {
         let optional_op = Inclusion::new(db);
         if let Some(op) = optional_op {
             return Some(Box::new(op));
@@ -100,7 +100,7 @@ impl std::fmt::Display for Inclusion {
     }
 }
 
-impl Operator for Inclusion {
+impl BinaryOperator for Inclusion {
     fn retrieve_matches(&self, lhs: &Match) -> Box<Iterator<Item = Match>> {
         if let (Some(start_lhs), Some(end_lhs)) = self.tok_helper.left_right_token_for(lhs.node) {
             // span length of LHS

--- a/src/annis/db/aql/operators/leftalignment.rs
+++ b/src/annis/db/aql/operators/leftalignment.rs
@@ -4,8 +4,8 @@ use crate::annis::db::token_helper;
 use crate::annis::db::token_helper::TokenHelper;
 use crate::annis::db::Graph;
 use crate::annis::db::Match;
-use crate::annis::operator::Operator;
-use crate::annis::operator::OperatorSpec;
+use crate::annis::operator::BinaryOperator;
+use crate::annis::operator::BinaryOperatorSpec;
 use crate::annis::types::{AnnoKeyID, Component, ComponentType};
 use std::sync::Arc;
 
@@ -28,14 +28,14 @@ lazy_static! {
     };
 }
 
-impl OperatorSpec for LeftAlignmentSpec {
+impl BinaryOperatorSpec for LeftAlignmentSpec {
     fn necessary_components(&self, _db: &Graph) -> Vec<Component> {
         let mut v: Vec<Component> = vec![COMPONENT_LEFT.clone()];
         v.append(&mut token_helper::necessary_components());
         v
     }
 
-    fn create_operator(&self, db: &Graph) -> Option<Box<Operator>> {
+    fn create_operator(&self, db: &Graph) -> Option<Box<BinaryOperator>> {
         let optional_op = LeftAlignment::new(db);
         if let Some(op) = optional_op {
             return Some(Box::new(op));
@@ -61,7 +61,7 @@ impl std::fmt::Display for LeftAlignment {
     }
 }
 
-impl Operator for LeftAlignment {
+impl BinaryOperator for LeftAlignment {
     
 
     fn retrieve_matches(&self, lhs: &Match) -> Box<Iterator<Item = Match>> {
@@ -96,7 +96,7 @@ impl Operator for LeftAlignment {
         false
     }
 
-    fn get_inverse_operator(&self) -> Option<Box<Operator>> {
+    fn get_inverse_operator(&self) -> Option<Box<BinaryOperator>> {
         Some(Box::new(self.clone()))
     }
 

--- a/src/annis/db/aql/operators/mod.rs
+++ b/src/annis/db/aql/operators/mod.rs
@@ -38,14 +38,15 @@ impl fmt::Display for RangeSpec {
     }
 }
 
-pub mod edge_op;
-pub mod identical_cov;
-pub mod identical_node;
-pub mod inclusion;
-pub mod overlap;
-pub mod precedence;
-pub mod leftalignment;
-pub mod rightalignment;
+mod arity;
+mod edge_op;
+mod identical_cov;
+mod identical_node;
+mod inclusion;
+mod overlap;
+mod precedence;
+mod leftalignment;
+mod rightalignment;
 
 pub use self::edge_op::{DominanceSpec, PartOfSubCorpusSpec, PointingSpec};
 pub use self::identical_cov::IdenticalCoverageSpec;

--- a/src/annis/db/aql/operators/mod.rs
+++ b/src/annis/db/aql/operators/mod.rs
@@ -56,4 +56,4 @@ pub use self::overlap::OverlapSpec;
 pub use self::leftalignment::LeftAlignmentSpec;
 pub use self::rightalignment::RightAlignmentSpec;
 pub use self::precedence::PrecedenceSpec;
-
+pub use self::arity::AritySpec;

--- a/src/annis/db/aql/operators/overlap.rs
+++ b/src/annis/db/aql/operators/overlap.rs
@@ -3,7 +3,7 @@ use crate::annis::db::token_helper;
 use crate::annis::db::token_helper::TokenHelper;
 use crate::annis::db::{Graph, Match};
 use crate::annis::operator::EstimationType;
-use crate::annis::operator::{Operator, OperatorSpec};
+use crate::annis::operator::{BinaryOperator, BinaryOperatorSpec};
 use crate::annis::types::{AnnoKeyID, Component, ComponentType, NodeID};
 use rustc_hash::FxHashSet;
 
@@ -37,7 +37,7 @@ lazy_static! {
     };
 }
 
-impl OperatorSpec for OverlapSpec {
+impl BinaryOperatorSpec for OverlapSpec {
     fn necessary_components(&self, _db: &Graph) -> Vec<Component> {
         let mut v: Vec<Component> = vec![
             COMPONENT_ORDER.clone(),
@@ -47,7 +47,7 @@ impl OperatorSpec for OverlapSpec {
         v
     }
 
-    fn create_operator(&self, db: &Graph) -> Option<Box<Operator>> {
+    fn create_operator(&self, db: &Graph) -> Option<Box<BinaryOperator>> {
         let optional_op = Overlap::new(db);
         if let Some(op) = optional_op {
             return Some(Box::new(op));
@@ -78,7 +78,7 @@ impl std::fmt::Display for Overlap {
     }
 }
 
-impl Operator for Overlap {
+impl BinaryOperator for Overlap {
     fn retrieve_matches(&self, lhs: &Match) -> Box<Iterator<Item = Match>> {
         // use set to filter out duplicates
         let mut result = FxHashSet::default();
@@ -136,7 +136,7 @@ impl Operator for Overlap {
         false
     }
 
-    fn get_inverse_operator(&self) -> Option<Box<Operator>> {
+    fn get_inverse_operator(&self) -> Option<Box<BinaryOperator>> {
         Some(Box::new(self.clone()))
     }
 

--- a/src/annis/db/aql/operators/precedence.rs
+++ b/src/annis/db/aql/operators/precedence.rs
@@ -4,7 +4,7 @@ use crate::annis::db::token_helper;
 use crate::annis::db::token_helper::TokenHelper;
 use crate::annis::db::{Graph, Match};
 use crate::annis::operator::EstimationType;
-use crate::annis::operator::{Operator, OperatorSpec};
+use crate::annis::operator::{BinaryOperator, BinaryOperatorSpec};
 use crate::annis::types::{AnnoKeyID, Component, ComponentType};
 
 use std;
@@ -42,7 +42,7 @@ lazy_static! {
     };
 }
 
-impl OperatorSpec for PrecedenceSpec {
+impl BinaryOperatorSpec for PrecedenceSpec {
     fn necessary_components(&self, _db: &Graph) -> Vec<Component> {
         let component_order = Component {
             ctype: ComponentType::Ordering,
@@ -62,7 +62,7 @@ impl OperatorSpec for PrecedenceSpec {
         v
     }
 
-    fn create_operator(&self, db: &Graph) -> Option<Box<Operator>> {
+    fn create_operator(&self, db: &Graph) -> Option<Box<BinaryOperator>> {
         let optional_op = Precedence::new(db, self.clone());
         if let Some(op) = optional_op {
             return Some(Box::new(op));
@@ -115,7 +115,7 @@ impl std::fmt::Display for Precedence {
     }
 }
 
-impl Operator for Precedence {
+impl BinaryOperator for Precedence {
     fn retrieve_matches(&self, lhs: &Match) -> Box<Iterator<Item = Match>> {
         let start = if self.spec.segmentation.is_some() {
             Some(lhs.node)
@@ -187,7 +187,7 @@ impl Operator for Precedence {
         EstimationType::SELECTIVITY(0.1)
     }
 
-    fn get_inverse_operator(&self) -> Option<Box<Operator>> {
+    fn get_inverse_operator(&self) -> Option<Box<BinaryOperator>> {
         // Check if order graph storages has the same inverse cost.
         // If not, we don't provide an inverse operator, because the plans would not account for the different costs
         if !self.gs_order.inverse_has_same_cost() {
@@ -219,7 +219,7 @@ impl std::fmt::Display for InversePrecedence {
     }
 }
 
-impl Operator for InversePrecedence {
+impl BinaryOperator for InversePrecedence {
     fn retrieve_matches(&self, lhs: &Match) -> Box<Iterator<Item = Match>> {
         let start = if self.spec.segmentation.is_some() {
             Some(lhs.node)
@@ -273,7 +273,7 @@ impl Operator for InversePrecedence {
         )
     }
 
-    fn get_inverse_operator(&self) -> Option<Box<Operator>> {
+    fn get_inverse_operator(&self) -> Option<Box<BinaryOperator>> {
         let prec = Precedence {
             gs_order: self.gs_order.clone(),
             gs_left: self.gs_left.clone(),

--- a/src/annis/db/aql/operators/rightalignment.rs
+++ b/src/annis/db/aql/operators/rightalignment.rs
@@ -4,8 +4,8 @@ use crate::annis::db::token_helper;
 use crate::annis::db::token_helper::TokenHelper;
 use crate::annis::db::Graph;
 use crate::annis::db::Match;
-use crate::annis::operator::Operator;
-use crate::annis::operator::OperatorSpec;
+use crate::annis::operator::BinaryOperator;
+use crate::annis::operator::BinaryOperatorSpec;
 use crate::annis::types::{AnnoKeyID, Component, ComponentType};
 use std::sync::Arc;
 
@@ -28,14 +28,14 @@ lazy_static! {
     };
 }
 
-impl OperatorSpec for RightAlignmentSpec {
+impl BinaryOperatorSpec for RightAlignmentSpec {
     fn necessary_components(&self, _db: &Graph) -> Vec<Component> {
         let mut v: Vec<Component> = vec![COMPONENT_RIGHT.clone()];
         v.append(&mut token_helper::necessary_components());
         v
     }
 
-    fn create_operator(&self, db: &Graph) -> Option<Box<Operator>> {
+    fn create_operator(&self, db: &Graph) -> Option<Box<BinaryOperator>> {
         let optional_op = RightAlignment::new(db);
         if let Some(op) = optional_op {
             return Some(Box::new(op));
@@ -61,7 +61,7 @@ impl std::fmt::Display for RightAlignment {
     }
 }
 
-impl Operator for RightAlignment {
+impl BinaryOperator for RightAlignment {
     
 
     fn retrieve_matches(&self, lhs: &Match) -> Box<Iterator<Item = Match>> {
@@ -96,7 +96,7 @@ impl Operator for RightAlignment {
         false
     }
 
-    fn get_inverse_operator(&self) -> Option<Box<Operator>> {
+    fn get_inverse_operator(&self) -> Option<Box<BinaryOperator>> {
         Some(Box::new(self.clone()))
     }
 

--- a/src/annis/db/aql/parser.lalrpop
+++ b/src/annis/db/aql/parser.lalrpop
@@ -5,6 +5,7 @@ use std::rc::Rc;
 use crate::annis::operator::EdgeAnnoSearchSpec;
 use crate::annis::db::exec::nodesearch::NodeSearchSpec;
 use crate::annis::db::aql::operators::{
+    AritySpec,
     OverlapSpec, 
     IdenticalCoverageSpec,
     PrecedenceSpec,
@@ -93,6 +94,11 @@ Literal : ast::Expr = {
             last_operand = t.1;
         }
         expr
+    },
+    // unary operator
+    <start: @L> <node_ref:NodeRef> <op:UnaryOpSpec> <end: @R> => {
+        let pos = Some(ast::Pos{start, end});
+        Expr::Terminal(ast::Literal::UnaryOp{node_ref, op, pos})
     },
     // legacy meta-data query `meta::doc="..."`
     <start: @L> "meta::" <name:QName> <cmp:ComparisionOperator> <text:TextSearch> <end: @R> => {
@@ -378,7 +384,18 @@ BinaryOpSpec : ast::BinaryOpSpec = {
     RIGHT_ALIGNED => ast::BinaryOpSpec::RightAlignment(RightAlignmentSpec {}),
     // Identical node
     IDENT_NODE => ast::BinaryOpSpec::IdenticalNode(IdenticalNodeSpec {}),
-    // TODO: add more operators
+    // TODO: add more binary operators
+}
+
+/// Unary operators only have one operand
+UnaryOpSpec : ast::UnaryOpSpec = {
+    // Part of subcorpus
+    ":arity" "=" <children:RangeSpec> => {
+        ast::UnaryOpSpec::Arity(AritySpec {
+            children
+        })
+    },
+    // TODO: add more unary operators
 }
 
 ComparisionOperator: ast::ComparisionOperator = {

--- a/src/annis/db/exec/binary_filter.rs
+++ b/src/annis/db/exec/binary_filter.rs
@@ -1,7 +1,7 @@
 use super::{CostEstimate, Desc, ExecutionNode};
 use crate::annis::db::query::conjunction::OperatorEntry;
 use crate::annis::db::Match;
-use crate::annis::operator::{EstimationType, Operator};
+use crate::annis::operator::{EstimationType, BinaryOperator};
 use std;
 
 pub struct BinaryFilter<'a> {
@@ -9,7 +9,7 @@ pub struct BinaryFilter<'a> {
     desc: Option<Desc>,
 }
 
-fn calculate_outputsize(op: &Operator, num_tuples: usize) -> usize {
+fn calculate_outputsize(op: &BinaryOperator, num_tuples: usize) -> usize {
     let output = match op.estimation_type() {
         EstimationType::SELECTIVITY(selectivity) => {
             let num_tuples = num_tuples as f64;

--- a/src/annis/db/exec/indexjoin.rs
+++ b/src/annis/db/exec/indexjoin.rs
@@ -2,7 +2,7 @@ use super::{Desc, ExecutionNode, NodeSearchDesc};
 use crate::annis::db::annostorage::AnnoStorage;
 use crate::annis::db::query::conjunction::OperatorEntry;
 use crate::annis::db::Match;
-use crate::annis::operator::{EstimationType, Operator};
+use crate::annis::operator::{EstimationType, BinaryOperator};
 use crate::annis::types::{AnnoKey, NodeID};
 use std;
 use std::iter::Peekable;
@@ -14,7 +14,7 @@ use std::sync::Arc;
 pub struct IndexJoin<'a> {
     lhs: Peekable<Box<ExecutionNode<Item = Vec<Match>> + 'a>>,
     rhs_candidate: Option<std::iter::Peekable<Box<Iterator<Item = Match>>>>,
-    op: Box<Operator>,
+    op: Box<BinaryOperator>,
     lhs_idx: usize,
     node_search_desc: Arc<NodeSearchDesc>,
     node_annos: Arc<AnnoStorage<NodeID>>,

--- a/src/annis/db/exec/indexjoin.rs
+++ b/src/annis/db/exec/indexjoin.rs
@@ -1,6 +1,6 @@
 use super::{Desc, ExecutionNode, NodeSearchDesc};
 use crate::annis::db::annostorage::AnnoStorage;
-use crate::annis::db::query::conjunction::OperatorEntry;
+use crate::annis::db::query::conjunction::BinaryOperatorEntry;
 use crate::annis::db::Match;
 use crate::annis::operator::{EstimationType, BinaryOperator};
 use crate::annis::types::{AnnoKey, NodeID};
@@ -34,7 +34,7 @@ impl<'a> IndexJoin<'a> {
     pub fn new(
         lhs: Box<ExecutionNode<Item = Vec<Match>> + 'a>,
         lhs_idx: usize,
-        op_entry: OperatorEntry,
+        op_entry: BinaryOperatorEntry,
         node_search_desc: Arc<NodeSearchDesc>,
         node_annos: Arc<AnnoStorage<NodeID>>,
         rhs_desc: Option<&Desc>,

--- a/src/annis/db/exec/mod.rs
+++ b/src/annis/db/exec/mod.rs
@@ -1,6 +1,6 @@
 use self::nodesearch::NodeSearch;
 use crate::annis::db::Match;
-use crate::annis::operator::{EstimationType, Operator};
+use crate::annis::operator::{EstimationType, BinaryOperator};
 use crate::annis::types::AnnoKeyID;
 
 use std;
@@ -24,7 +24,7 @@ pub struct Desc {
     pub cost: Option<CostEstimate>,
 }
 
-fn calculate_outputsize(op: &Operator, cost_lhs: &CostEstimate, cost_rhs: &CostEstimate) -> usize {
+fn calculate_outputsize(op: &BinaryOperator, cost_lhs: &CostEstimate, cost_rhs: &CostEstimate) -> usize {
     let output = match op.estimation_type() {
         EstimationType::SELECTIVITY(selectivity) => {
             let num_tuples = (cost_lhs.output * cost_rhs.output) as f64;
@@ -71,7 +71,7 @@ impl Desc {
     }
 
     pub fn join(
-        op: &Operator,
+        op: &BinaryOperator,
         lhs: Option<&Desc>,
         rhs: Option<&Desc>,
         impl_description: &str,

--- a/src/annis/db/exec/mod.rs
+++ b/src/annis/db/exec/mod.rs
@@ -219,7 +219,7 @@ impl ExecutionNode for EmptyResultSet {
     }
 }
 
-pub mod binary_filter;
+pub mod filter;
 pub mod indexjoin;
 pub mod nestedloop;
 pub mod nodesearch;

--- a/src/annis/db/exec/nestedloop.rs
+++ b/src/annis/db/exec/nestedloop.rs
@@ -1,5 +1,5 @@
 use super::{Desc, ExecutionNode};
-use crate::annis::db::query::conjunction::OperatorEntry;
+use crate::annis::db::query::conjunction::BinaryOperatorEntry;
 use crate::annis::db::Match;
 use crate::annis::operator::BinaryOperator;
 use std::iter::Peekable;
@@ -21,7 +21,7 @@ pub struct NestedLoop<'a> {
 
 impl<'a> NestedLoop<'a> {
     pub fn new(
-        op_entry: OperatorEntry,
+        op_entry: BinaryOperatorEntry,
         lhs: Box<ExecutionNode<Item = Vec<Match>> + 'a>,
         rhs: Box<ExecutionNode<Item = Vec<Match>> + 'a>,
         lhs_idx: usize,

--- a/src/annis/db/exec/nestedloop.rs
+++ b/src/annis/db/exec/nestedloop.rs
@@ -1,13 +1,13 @@
 use super::{Desc, ExecutionNode};
 use crate::annis::db::query::conjunction::OperatorEntry;
 use crate::annis::db::Match;
-use crate::annis::operator::Operator;
+use crate::annis::operator::BinaryOperator;
 use std::iter::Peekable;
 
 pub struct NestedLoop<'a> {
     outer: Peekable<Box<ExecutionNode<Item = Vec<Match>> + 'a>>,
     inner: Box<ExecutionNode<Item = Vec<Match>> + 'a>,
-    op: Box<Operator>,
+    op: Box<BinaryOperator>,
     inner_idx: usize,
     outer_idx: usize,
     inner_cache: Vec<Vec<Match>>,

--- a/src/annis/db/exec/parallel/indexjoin.rs
+++ b/src/annis/db/exec/parallel/indexjoin.rs
@@ -1,6 +1,6 @@
 use super::super::{Desc, ExecutionNode, NodeSearchDesc};
 use crate::annis::db::annostorage::AnnoStorage;
-use crate::annis::db::query::conjunction::OperatorEntry;
+use crate::annis::db::query::conjunction::BinaryOperatorEntry;
 use crate::annis::db::Match;
 use crate::annis::operator::{EstimationType, BinaryOperator};
 use crate::annis::types::{AnnoKey, NodeID};
@@ -37,7 +37,7 @@ impl<'a> IndexJoin<'a> {
     pub fn new(
         lhs: Box<ExecutionNode<Item = Vec<Match>> + 'a>,
         lhs_idx: usize,
-        op_entry: OperatorEntry,
+        op_entry: BinaryOperatorEntry,
         node_search_desc: Arc<NodeSearchDesc>,
         node_annos: Arc<AnnoStorage<NodeID>>,
         rhs_desc: Option<&Desc>,

--- a/src/annis/db/exec/parallel/indexjoin.rs
+++ b/src/annis/db/exec/parallel/indexjoin.rs
@@ -2,7 +2,7 @@ use super::super::{Desc, ExecutionNode, NodeSearchDesc};
 use crate::annis::db::annostorage::AnnoStorage;
 use crate::annis::db::query::conjunction::OperatorEntry;
 use crate::annis::db::Match;
-use crate::annis::operator::{EstimationType, Operator};
+use crate::annis::operator::{EstimationType, BinaryOperator};
 use crate::annis::types::{AnnoKey, NodeID};
 use rayon::prelude::*;
 use std::iter::Peekable;
@@ -17,7 +17,7 @@ const MAX_BUFFER_SIZE: usize = 512;
 pub struct IndexJoin<'a> {
     lhs: Peekable<Box<ExecutionNode<Item = Vec<Match>> + 'a>>,
     match_receiver: Option<Receiver<Vec<Match>>>,
-    op: Arc<Operator>,
+    op: Arc<BinaryOperator>,
     lhs_idx: usize,
     node_search_desc: Arc<NodeSearchDesc>,
     node_annos: Arc<AnnoStorage<NodeID>>,
@@ -114,11 +114,11 @@ impl<'a> IndexJoin<'a> {
         }
 
         let node_search_desc: Arc<NodeSearchDesc> = self.node_search_desc.clone();
-        let op: Arc<Operator> = self.op.clone();
+        let op: Arc<BinaryOperator> = self.op.clone();
         let lhs_idx = self.lhs_idx;
         let node_annos = self.node_annos.clone();
 
-        let op: &Operator = op.as_ref();
+        let op: &BinaryOperator = op.as_ref();
         let global_reflexivity = self.global_reflexivity;
 
         // find all RHS in parallel
@@ -181,7 +181,7 @@ impl<'a> IndexJoin<'a> {
 
 fn next_candidates(
     m_lhs: &[Match],
-    op: &Operator,
+    op: &BinaryOperator,
     lhs_idx: usize,
     node_annos: &Arc<AnnoStorage<NodeID>>,
     node_search_desc: &Arc<NodeSearchDesc>,

--- a/src/annis/db/exec/parallel/nestedloop.rs
+++ b/src/annis/db/exec/parallel/nestedloop.rs
@@ -1,5 +1,5 @@
 use super::super::{Desc, ExecutionNode};
-use crate::annis::db::query::conjunction::OperatorEntry;
+use crate::annis::db::query::conjunction::BinaryOperatorEntry;
 use crate::annis::db::Match;
 use crate::annis::operator::BinaryOperator;
 use rayon::prelude::*;
@@ -30,7 +30,7 @@ type MatchCandidate = (Vec<Match>, Vec<Match>, Sender<Vec<Match>>);
 
 impl<'a> NestedLoop<'a> {
     pub fn new(
-        op_entry: OperatorEntry,
+        op_entry: BinaryOperatorEntry,
         lhs: Box<ExecutionNode<Item = Vec<Match>> + 'a>,
         rhs: Box<ExecutionNode<Item = Vec<Match>> + 'a>,
         lhs_idx: usize,

--- a/src/annis/db/exec/parallel/nestedloop.rs
+++ b/src/annis/db/exec/parallel/nestedloop.rs
@@ -1,7 +1,7 @@
 use super::super::{Desc, ExecutionNode};
 use crate::annis::db::query::conjunction::OperatorEntry;
 use crate::annis::db::Match;
-use crate::annis::operator::Operator;
+use crate::annis::operator::BinaryOperator;
 use rayon::prelude::*;
 use std::iter::Peekable;
 use std::sync::mpsc::{channel, Receiver, Sender};
@@ -12,7 +12,7 @@ const MAX_BUFFER_SIZE: usize = 512;
 pub struct NestedLoop<'a> {
     outer: Peekable<Box<ExecutionNode<Item = Vec<Match>> + 'a>>,
     inner: Box<ExecutionNode<Item = Vec<Match>> + 'a>,
-    op: Arc<Operator>,
+    op: Arc<BinaryOperator>,
     inner_idx: usize,
     outer_idx: usize,
 
@@ -162,7 +162,7 @@ impl<'a> NestedLoop<'a> {
         let inner_idx = self.inner_idx;
         let op = self.op.clone();
 
-        let op: &Operator = op.as_ref();
+        let op: &BinaryOperator = op.as_ref();
         let global_reflexivity = self.global_reflexivity;
 
         match_candidate_buffer

--- a/src/annis/db/query/conjunction.rs
+++ b/src/annis/db/query/conjunction.rs
@@ -11,7 +11,7 @@ use crate::annis::db::AnnotationStorage;
 use crate::annis::db::Graph;
 use crate::annis::db::Match;
 use crate::annis::errors::*;
-use crate::annis::operator::{BinaryOperator, BinaryOperatorSpec};
+use crate::annis::operator::{BinaryOperator, BinaryOperatorSpec, UnaryOperatorSpec};
 use crate::annis::types::{Component, Edge, LineColumnRange, QueryAttributeDescription};
 use rand::distributions::Distribution;
 use rand::distributions::Uniform;
@@ -23,11 +23,17 @@ use std::iter::FromIterator;
 use std::sync::Arc;
 
 #[derive(Debug)]
-struct OperatorSpecEntry<'a> {
+struct BinaryOperatorSpecEntry<'a> {
     op: Box<BinaryOperatorSpec + 'a>,
     idx_left: usize,
     idx_right: usize,
     global_reflexivity: bool,
+}
+
+#[derive(Debug)]
+struct UnaryOperatorSpecEntry<'a> {
+    op: Box<UnaryOperatorSpec + 'a>,
+    idx: usize,
 }
 
 pub struct OperatorEntry {
@@ -40,7 +46,8 @@ pub struct OperatorEntry {
 #[derive(Debug)]
 pub struct Conjunction<'a> {
     nodes: Vec<(String, NodeSearchSpec)>,
-    operators: Vec<OperatorSpecEntry<'a>>,
+    binary_operators: Vec<BinaryOperatorSpecEntry<'a>>,
+    unary_operators: Vec<UnaryOperatorSpecEntry<'a>>,
     variables: HashMap<String, usize>,
     location_in_query: HashMap<String, LineColumnRange>,
     var_idx_offset: usize,
@@ -70,7 +77,7 @@ fn update_components_for_nodes(
 }
 
 fn should_switch_operand_order(
-    op_spec: &OperatorSpecEntry,
+    op_spec: &BinaryOperatorSpecEntry,
     node2cost: &BTreeMap<usize, CostEstimate>,
 ) -> bool {
     if let (Some(cost_lhs), Some(cost_rhs)) = (
@@ -161,21 +168,11 @@ fn create_join<'b>(
     // use nested loop as "fallback"
     if config.use_parallel_joins {
         let join = parallel::nestedloop::NestedLoop::new(
-            op_entry,
-            exec_left,
-            exec_right,
-            idx_left,
-            idx_right,
+            op_entry, exec_left, exec_right, idx_left, idx_right,
         );
         Box::new(join)
     } else {
-        let join = NestedLoop::new(
-            op_entry,
-            exec_left,
-            exec_right,
-            idx_left,
-            idx_right,
-        );
+        let join = NestedLoop::new(op_entry, exec_left, exec_right, idx_left, idx_right);
         Box::new(join)
     }
 }
@@ -184,7 +181,8 @@ impl<'a> Conjunction<'a> {
     pub fn new() -> Conjunction<'a> {
         Conjunction {
             nodes: vec![],
-            operators: vec![],
+            binary_operators: vec![],
+            unary_operators: vec![],
             variables: HashMap::default(),
             location_in_query: HashMap::default(),
             var_idx_offset: 0,
@@ -194,7 +192,8 @@ impl<'a> Conjunction<'a> {
     pub fn with_offset(var_idx_offset: usize) -> Conjunction<'a> {
         Conjunction {
             nodes: vec![],
-            operators: vec![],
+            binary_operators: vec![],
+            unary_operators: vec![],
             variables: HashMap::default(),
             location_in_query: HashMap::default(),
             var_idx_offset,
@@ -247,6 +246,28 @@ impl<'a> Conjunction<'a> {
         }
         variable
     }
+
+    pub fn add_unary_operator_from_query(
+        &mut self,
+        op: Box<UnaryOperatorSpec>,
+        var: &str,
+        location: Option<LineColumnRange>,
+    ) -> Result<()>  {
+        if let Some(idx) = self.variables.get(var) {
+            self.unary_operators.push(UnaryOperatorSpecEntry {
+                op,
+                idx: *idx,
+            });
+            return Ok(());
+        } else {
+            return Err(ErrorKind::AQLSemanticError(
+                format!("Operand '#{}' not found", var).into(),
+                location,
+            )
+            .into());
+        }
+    }
+
     pub fn add_operator(
         &mut self,
         op: Box<BinaryOperatorSpec>,
@@ -268,7 +289,7 @@ impl<'a> Conjunction<'a> {
         //let original_order = self.operators.len();
         if let Some(idx_left) = self.variables.get(var_left) {
             if let Some(idx_right) = self.variables.get(var_right) {
-                self.operators.push(OperatorSpecEntry {
+                self.binary_operators.push(BinaryOperatorSpecEntry {
                     op,
                     idx_left: *idx_left,
                     idx_right: *idx_right,
@@ -309,7 +330,7 @@ impl<'a> Conjunction<'a> {
     pub fn necessary_components(&self, db: &Graph) -> Vec<Component> {
         let mut result = vec![];
 
-        for op_entry in &self.operators {
+        for op_entry in &self.binary_operators {
             let mut c = op_entry.op.necessary_components(db);
             result.append(&mut c);
         }
@@ -320,23 +341,19 @@ impl<'a> Conjunction<'a> {
         result
     }
 
-    fn optimize_join_order_heuristics(
-        &self,
-        db: &'a Graph,
-        config: &Config,
-    ) -> Result<Vec<usize>> {
+    fn optimize_join_order_heuristics(&self, db: &'a Graph, config: &Config) -> Result<Vec<usize>> {
         // check if there is something to optimize
-        if self.operators.is_empty() {
+        if self.binary_operators.is_empty() {
             return Ok(vec![]);
-        } else if self.operators.len() == 1 {
+        } else if self.binary_operators.len() == 1 {
             return Ok(vec![0]);
         }
 
         // use a constant seed to make the result deterministic
         let mut rng = XorShiftRng::from_seed(*b"Graphs are great");
-        let dist = Uniform::from(0..self.operators.len());
+        let dist = Uniform::from(0..self.binary_operators.len());
 
-        let mut best_operator_order = Vec::from_iter(0..self.operators.len());
+        let mut best_operator_order = Vec::from_iter(0..self.binary_operators.len());
 
         // TODO: cache the base estimates
         let initial_plan =
@@ -357,7 +374,7 @@ impl<'a> Conjunction<'a> {
         );
 
         let num_new_generations = 4;
-        let max_unsuccessful_tries = 5 * self.operators.len();
+        let max_unsuccessful_tries = 5 * self.binary_operators.len();
         let mut unsucessful = 0;
         while unsucessful < max_unsuccessful_tries {
             let mut family_operators: Vec<Vec<usize>> = Vec::new();
@@ -382,8 +399,7 @@ impl<'a> Conjunction<'a> {
 
             let mut found_better_plan = false;
             for op_order in family_operators.iter().skip(1) {
-                let alt_plan =
-                    self.make_exec_plan_with_order(db, config, op_order.clone())?;
+                let alt_plan = self.make_exec_plan_with_order(db, config, op_order.clone())?;
                 let alt_cost = alt_plan
                     .get_desc()
                     .ok_or("Plan description missing")?
@@ -420,7 +436,7 @@ impl<'a> Conjunction<'a> {
         &'a self,
         node_search_desc: Arc<NodeSearchDesc>,
         desc: Option<&Desc>,
-        op_spec_entries: Box<Iterator<Item = &'a OperatorSpecEntry> + 'a>,
+        op_spec_entries: Box<Iterator<Item = &'a BinaryOperatorSpecEntry> + 'a>,
         db: &'a Graph,
     ) -> Option<Box<ExecutionNode<Item = Vec<Match>> + 'a>> {
         let desc = desc?;
@@ -539,7 +555,7 @@ impl<'a> Conjunction<'a> {
                     let node_by_component_search = self.optimize_node_search_by_operator(
                         node_search.get_node_search_desc(),
                         node_search.get_desc(),
-                        Box::new(self.operators.iter()),
+                        Box::new(self.binary_operators.iter()),
                         db,
                     );
 
@@ -556,14 +572,15 @@ impl<'a> Conjunction<'a> {
 
         // 2. add the joins which produce the results in operand order
         for i in operator_order {
-            let op_spec_entry: &OperatorSpecEntry<'a> = &self.operators[i];
+            let op_spec_entry: &BinaryOperatorSpecEntry<'a> = &self.binary_operators[i];
 
-            let mut op: Box<BinaryOperator> = op_spec_entry.op.create_operator(db).ok_or_else(|| {
-                ErrorKind::ImpossibleSearch(format!(
-                    "could not create operator {:?}",
-                    op_spec_entry
-                ))
-            })?;
+            let mut op: Box<BinaryOperator> =
+                op_spec_entry.op.create_operator(db).ok_or_else(|| {
+                    ErrorKind::ImpossibleSearch(format!(
+                        "could not create operator {:?}",
+                        op_spec_entry
+                    ))
+                })?;
 
             let mut spec_idx_left = op_spec_entry.idx_left;
             let mut spec_idx_right = op_spec_entry.idx_right;

--- a/src/annis/db/query/conjunction.rs
+++ b/src/annis/db/query/conjunction.rs
@@ -11,7 +11,7 @@ use crate::annis::db::AnnotationStorage;
 use crate::annis::db::Graph;
 use crate::annis::db::Match;
 use crate::annis::errors::*;
-use crate::annis::operator::{Operator, OperatorSpec};
+use crate::annis::operator::{BinaryOperator, BinaryOperatorSpec};
 use crate::annis::types::{Component, Edge, LineColumnRange, QueryAttributeDescription};
 use rand::distributions::Distribution;
 use rand::distributions::Uniform;
@@ -24,14 +24,14 @@ use std::sync::Arc;
 
 #[derive(Debug)]
 struct OperatorSpecEntry<'a> {
-    op: Box<OperatorSpec + 'a>,
+    op: Box<BinaryOperatorSpec + 'a>,
     idx_left: usize,
     idx_right: usize,
     global_reflexivity: bool,
 }
 
 pub struct OperatorEntry {
-    pub op: Box<Operator>,
+    pub op: Box<BinaryOperator>,
     pub node_nr_left: usize,
     pub node_nr_right: usize,
     pub global_reflexivity: bool,
@@ -249,7 +249,7 @@ impl<'a> Conjunction<'a> {
     }
     pub fn add_operator(
         &mut self,
-        op: Box<OperatorSpec>,
+        op: Box<BinaryOperatorSpec>,
         var_left: &str,
         var_right: &str,
         global_reflexivity: bool,
@@ -259,7 +259,7 @@ impl<'a> Conjunction<'a> {
 
     pub fn add_operator_from_query(
         &mut self,
-        op: Box<OperatorSpec>,
+        op: Box<BinaryOperatorSpec>,
         var_left: &str,
         var_right: &str,
         location: Option<LineColumnRange>,
@@ -558,7 +558,7 @@ impl<'a> Conjunction<'a> {
         for i in operator_order {
             let op_spec_entry: &OperatorSpecEntry<'a> = &self.operators[i];
 
-            let mut op: Box<Operator> = op_spec_entry.op.create_operator(db).ok_or_else(|| {
+            let mut op: Box<BinaryOperator> = op_spec_entry.op.create_operator(db).ok_or_else(|| {
                 ErrorKind::ImpossibleSearch(format!(
                     "could not create operator {:?}",
                     op_spec_entry

--- a/src/annis/db/query/conjunction.rs
+++ b/src/annis/db/query/conjunction.rs
@@ -334,6 +334,11 @@ impl<'a> Conjunction<'a> {
     pub fn necessary_components(&self, db: &Graph) -> Vec<Component> {
         let mut result = vec![];
 
+        for op_entry in &self.unary_operators {
+            let mut c = op_entry.op.necessary_components(db);
+            result.append(&mut c);
+        }
+
         for op_entry in &self.binary_operators {
             let mut c = op_entry.op.necessary_components(db);
             result.append(&mut c);

--- a/src/annis/operator.rs
+++ b/src/annis/operator.rs
@@ -139,7 +139,7 @@ pub enum EstimationType {
     MIN,
 }
 
-pub trait Operator: std::fmt::Display + Send + Sync {
+pub trait BinaryOperator: std::fmt::Display + Send + Sync {
     fn retrieve_matches(&self, lhs: &Match) -> Box<Iterator<Item = Match>>;
 
     fn filter_match(&self, lhs: &Match, rhs: &Match) -> bool;
@@ -148,7 +148,7 @@ pub trait Operator: std::fmt::Display + Send + Sync {
         true
     }
 
-    fn get_inverse_operator(&self) -> Option<Box<Operator>> {
+    fn get_inverse_operator(&self) -> Option<Box<BinaryOperator>> {
         None
     }
 
@@ -161,10 +161,10 @@ pub trait Operator: std::fmt::Display + Send + Sync {
     }
 }
 
-pub trait OperatorSpec: std::fmt::Debug {
+pub trait BinaryOperatorSpec: std::fmt::Debug {
     fn necessary_components(&self, db: &Graph) -> Vec<Component>;
 
-    fn create_operator(&self, db: &Graph) -> Option<Box<Operator>>;
+    fn create_operator(&self, db: &Graph) -> Option<Box<BinaryOperator>>;
 
     fn get_edge_anno_spec(&self) -> Option<EdgeAnnoSearchSpec> {
         None

--- a/src/annis/operator.rs
+++ b/src/annis/operator.rs
@@ -177,7 +177,7 @@ pub trait UnaryOperatorSpec: std::fmt::Debug {
     fn create_operator(&self, db: &Graph) -> Option<Box<UnaryOperator>>;
 }
 
-pub trait UnaryOperator {
+pub trait UnaryOperator : std::fmt::Display + Send + Sync {
 
     fn filter_match(&self, m: &Match) -> bool;
 

--- a/src/annis/operator.rs
+++ b/src/annis/operator.rs
@@ -173,5 +173,15 @@ pub trait BinaryOperatorSpec: std::fmt::Debug {
 
 pub trait UnaryOperatorSpec: std::fmt::Debug {
     fn necessary_components(&self, db: &Graph) -> Vec<Component>;
-    fn create_filter(&self, db: &Graph) -> Box<Fn(&Match) -> bool>;
+
+    fn create_operator(&self, db: &Graph) -> Option<Box<UnaryOperator>>;
+}
+
+pub trait UnaryOperator {
+
+    fn filter_match(&self, m: &Match) -> bool;
+
+    fn estimation_type(&self) -> EstimationType {
+        EstimationType::SELECTIVITY(0.1)
+    }
 }

--- a/src/annis/operator.rs
+++ b/src/annis/operator.rs
@@ -170,3 +170,8 @@ pub trait BinaryOperatorSpec: std::fmt::Debug {
         None
     }
 }
+
+pub trait UnaryOperatorSpec: std::fmt::Debug {
+    fn necessary_components(&self, db: &Graph) -> Vec<Component>;
+    fn create_filter(&self, db: &Graph) -> Box<Fn(&Match) -> bool>;
+}

--- a/tests/searchtest_queries.csv
+++ b/tests/searchtest_queries.csv
@@ -49,6 +49,7 @@ TokenPrecedence,"tiger:pos=""NN"" .2,10 tiger:pos=""ART""",pcc2.1,5484
 TokenPrecedenceThreeNodes,"tiger:pos=""NN"" .2,10 tiger:pos=""ART"" . tiger:pos=""NN""",pcc2.1,3775
 PPNotModifier,"cat=""S"" & cat=""PP"" & #1 >[func!=""MO""] #2",pcc2.1,129
 BrandenBurgSentence,"tiger:cat=""S"" & tok=/Brandenburg.*/ & #1 >* #2",pcc2.1,46
+NPThreeOut,"cat=""NP"" & #1:arity=3 & node & #1 > #2 & #2:arity=3",pcc2.1,254
 DiplNameSearch,dipl,RIDGES_Herbology_Version7.0,252777
 PrecedenceMixedSpanTok,"default_ns:pos=""PTKANT"" . node",RIDGES_Herbology_Version7.0,28
 NotWennRegex,KOUS_sem=/konditional/ _i_ lemma!=/wenn.*/,RIDGES_Herbology_Version7.0,119


### PR DESCRIPTION
Until now, only binary operators were supported. This PR therefore also adds the general infrastructure to support unary operators.