### PR TITLE
Automatic creation of inherited coverage edges

### DIFF
--- a/src/annis/db/aql/operators/arity.rs
+++ b/src/annis/db/aql/operators/arity.rs
@@ -4,6 +4,7 @@ use crate::annis::operator::EstimationType;
 use crate::annis::operator::{UnaryOperator, UnaryOperatorSpec};
 use crate::graph::{Component, ComponentType, Match, NodeID};
 use crate::Graph;
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use rustc_hash::FxHashSet;
@@ -15,8 +16,8 @@ pub struct AritySpec {
 }
 
 impl UnaryOperatorSpec for AritySpec {
-    fn necessary_components(&self, db: &Graph) -> Vec<Component> {
-        let mut result = Vec::default();
+    fn necessary_components(&self, db: &Graph) -> HashSet<Component> {
+        let mut result = HashSet::default();
         result.extend(db.get_all_components(Some(ComponentType::Dominance), None));
         result.extend(db.get_all_components(Some(ComponentType::Pointing), None));
         result
@@ -78,7 +79,7 @@ impl UnaryOperator for ArityOperator {
     fn estimation_type(&self) -> EstimationType {
         if let RangeSpec::Bound { min_dist, max_dist } = self.allowed_range {
             let mut min_matches_any = false;
-            let mut max_sel : f64 = 0.0;
+            let mut max_sel: f64 = 0.0;
 
             for gs in self.graphstorages.iter() {
                 if let Some(stats) = gs.get_statistics() {
@@ -104,7 +105,7 @@ impl UnaryOperator for ArityOperator {
                 }
             }
 
-            if min_matches_any {                
+            if min_matches_any {
                 if max_sel >= 1.0 {
                     EstimationType::SELECTIVITY(1.0)
                 } else {

--- a/src/annis/db/aql/operators/equal_value.rs
+++ b/src/annis/db/aql/operators/equal_value.rs
@@ -4,6 +4,7 @@ use crate::annis::operator::*;
 use crate::annis::types::{AnnoKey, Component, NodeID};
 use std;
 use std::sync::Arc;
+use std::collections::HashSet;
 
 #[derive(Debug, Clone, PartialOrd, Ord, Hash, PartialEq, Eq)]
 pub struct EqualValueSpec {
@@ -14,8 +15,8 @@ pub struct EqualValueSpec {
 
 
 impl BinaryOperatorSpec for EqualValueSpec {
-    fn necessary_components(&self, _db: &Graph) -> Vec<Component> {
-        vec![]
+    fn necessary_components(&self, _db: &Graph) -> HashSet<Component> {
+        HashSet::default()
     }
 
     fn create_operator<'a>(&self, db: &Graph) -> Option<Box<dyn BinaryOperator>> {

--- a/src/annis/db/aql/operators/identical_cov.rs
+++ b/src/annis/db/aql/operators/identical_cov.rs
@@ -37,9 +37,9 @@ lazy_static! {
 }
 
 impl BinaryOperatorSpec for IdenticalCoverageSpec {
-    fn necessary_components(&self, _db: &Graph) -> Vec<Component> {
+    fn necessary_components(&self, db: &Graph) -> Vec<Component> {
         let mut v: Vec<Component> = vec![COMPONENT_LEFT.clone(), COMPONENT_ORDER.clone()];
-        v.append(&mut token_helper::necessary_components());
+        v.append(&mut token_helper::necessary_components(db));
         v
     }
 

--- a/src/annis/db/aql/operators/identical_cov.rs
+++ b/src/annis/db/aql/operators/identical_cov.rs
@@ -8,6 +8,7 @@ use crate::annis::types::{AnnoKeyID, Component, ComponentType};
 
 use std;
 use std::sync::Arc;
+use std::collections::HashSet;
 
 #[derive(Clone, Debug, PartialOrd, Ord, Hash, PartialEq, Eq)]
 pub struct IdenticalCoverageSpec;
@@ -37,9 +38,11 @@ lazy_static! {
 }
 
 impl BinaryOperatorSpec for IdenticalCoverageSpec {
-    fn necessary_components(&self, db: &Graph) -> Vec<Component> {
-        let mut v: Vec<Component> = vec![COMPONENT_LEFT.clone(), COMPONENT_ORDER.clone()];
-        v.append(&mut token_helper::necessary_components(db));
+    fn necessary_components(&self, db: &Graph) -> HashSet<Component> {
+        let mut v = HashSet::new();
+        v.insert(COMPONENT_LEFT.clone());
+        v.insert(COMPONENT_ORDER.clone());
+        v.extend(token_helper::necessary_components(db));
         v
     }
 

--- a/src/annis/db/aql/operators/identical_node.rs
+++ b/src/annis/db/aql/operators/identical_node.rs
@@ -2,13 +2,14 @@ use crate::annis::db::{Graph, Match};
 use crate::annis::operator::*;
 use crate::annis::types::{AnnoKeyID, Component};
 use std;
+use std::collections::HashSet;
 
 #[derive(Debug, Clone, PartialOrd, Ord, Hash, PartialEq, Eq)]
 pub struct IdenticalNodeSpec;
 
 impl BinaryOperatorSpec for IdenticalNodeSpec {
-    fn necessary_components(&self, _db: &Graph) -> Vec<Component> {
-        vec![]
+    fn necessary_components(&self, _db: &Graph) -> HashSet<Component> {
+        HashSet::default()
     }
 
     fn create_operator(&self, _db: &Graph) -> Option<Box<BinaryOperator>> {

--- a/src/annis/db/aql/operators/inclusion.rs
+++ b/src/annis/db/aql/operators/inclusion.rs
@@ -7,7 +7,7 @@ use crate::annis::operator::{BinaryOperator, BinaryOperatorSpec};
 use crate::annis::types::{AnnoKeyID, Component, ComponentType};
 
 use std;
-use std::collections::VecDeque;
+use std::collections::{HashSet, VecDeque};
 use std::sync::Arc;
 
 #[derive(Clone, Debug, PartialOrd, Ord, Hash, PartialEq, Eq)]
@@ -47,14 +47,13 @@ lazy_static! {
 }
 
 impl BinaryOperatorSpec for InclusionSpec {
-    fn necessary_components(&self, db: &Graph) -> Vec<Component> {
-        let mut v: Vec<Component> = vec![
-            COMPONENT_ORDER.clone(),
-            COMPONENT_LEFT.clone(),
-            COMPONENT_RIGHT.clone(),
-        ];
+    fn necessary_components(&self, db: &Graph) -> HashSet<Component> {
+        let mut v = HashSet::default();
+        v.insert(COMPONENT_ORDER.clone());
+        v.insert(COMPONENT_LEFT.clone());
+        v.insert(COMPONENT_RIGHT.clone());
         v.extend(db.get_all_components(Some(ComponentType::Coverage), None));
-        v.append(&mut token_helper::necessary_components(db));
+        v.extend(token_helper::necessary_components(db));
         v
     }
 

--- a/src/annis/db/aql/operators/inclusion.rs
+++ b/src/annis/db/aql/operators/inclusion.rs
@@ -54,14 +54,14 @@ lazy_static! {
 }
 
 impl BinaryOperatorSpec for InclusionSpec {
-    fn necessary_components(&self, _db: &Graph) -> Vec<Component> {
+    fn necessary_components(&self, db: &Graph) -> Vec<Component> {
         let mut v: Vec<Component> = vec![
             COMPONENT_ORDER.clone(),
             COMPONENT_LEFT.clone(),
             COMPONENT_RIGHT.clone(),
             COMPONENT_COV.clone(),
         ];
-        v.append(&mut token_helper::necessary_components());
+        v.append(&mut token_helper::necessary_components(db));
         v
     }
 

--- a/src/annis/db/aql/operators/leftalignment.rs
+++ b/src/annis/db/aql/operators/leftalignment.rs
@@ -1,13 +1,11 @@
-use crate::annis::operator::EstimationType;
-use crate::annis::db::graphstorage::GraphStorage;
 use crate::annis::db::token_helper;
 use crate::annis::db::token_helper::TokenHelper;
 use crate::annis::db::Graph;
 use crate::annis::db::Match;
 use crate::annis::operator::BinaryOperator;
 use crate::annis::operator::BinaryOperatorSpec;
-use crate::annis::types::{AnnoKeyID, Component, ComponentType};
-use std::sync::Arc;
+use crate::annis::operator::EstimationType;
+use crate::annis::types::{AnnoKeyID, Component};
 use std::collections::HashSet;
 
 #[derive(Clone, Debug, PartialOrd, Ord, Hash, PartialEq, Eq)]
@@ -15,24 +13,12 @@ pub struct LeftAlignmentSpec;
 
 #[derive(Clone)]
 pub struct LeftAlignment {
-    gs_left: Arc<GraphStorage>,
     tok_helper: TokenHelper,
-}
-
-lazy_static! {
-    static ref COMPONENT_LEFT: Component = {
-        Component {
-            ctype: ComponentType::LeftToken,
-            layer: String::from("annis"),
-            name: String::from(""),
-        }
-    };
 }
 
 impl BinaryOperatorSpec for LeftAlignmentSpec {
     fn necessary_components(&self, db: &Graph) -> HashSet<Component> {
         let mut v = HashSet::default();
-        v.insert(COMPONENT_LEFT.clone());
         v.extend(token_helper::necessary_components(db));
         v
     }
@@ -49,11 +35,9 @@ impl BinaryOperatorSpec for LeftAlignmentSpec {
 
 impl LeftAlignment {
     pub fn new(db: &Graph) -> Option<LeftAlignment> {
-        let gs_left = db.get_graphstorage(&COMPONENT_LEFT)?;
-
         let tok_helper = TokenHelper::new(db)?;
 
-        Some(LeftAlignment { gs_left, tok_helper })
+        Some(LeftAlignment { tok_helper })
     }
 }
 
@@ -64,8 +48,6 @@ impl std::fmt::Display for LeftAlignment {
 }
 
 impl BinaryOperator for LeftAlignment {
-    
-
     fn retrieve_matches(&self, lhs: &Match) -> Box<Iterator<Item = Match>> {
         let mut aligned = Vec::default();
 
@@ -74,10 +56,15 @@ impl BinaryOperator for LeftAlignment {
                 node: lhs_token,
                 anno_key: AnnoKeyID::default(),
             });
-            aligned.extend(self.gs_left.get_ingoing_edges(lhs_token).map(|n| Match {
-                node: n,
-                anno_key: AnnoKeyID::default(),
-            }));
+            aligned.extend(
+                self.tok_helper
+                    .get_gs_left_token()
+                    .get_ingoing_edges(lhs_token)
+                    .map(|n| Match {
+                        node: n,
+                        anno_key: AnnoKeyID::default(),
+                    }),
+            );
         }
 
         Box::from(aligned.into_iter())
@@ -103,7 +90,7 @@ impl BinaryOperator for LeftAlignment {
     }
 
     fn estimation_type(&self) -> EstimationType {
-        if let Some(stats_left) = self.gs_left.get_statistics() {
+        if let Some(stats_left) = self.tok_helper.get_gs_left_token().get_statistics() {
             let aligned_nodes_per_token: f64 = stats_left.inverse_fan_out_99_percentile as f64;
             return EstimationType::SELECTIVITY(aligned_nodes_per_token / (stats_left.nodes as f64));
         }

--- a/src/annis/db/aql/operators/leftalignment.rs
+++ b/src/annis/db/aql/operators/leftalignment.rs
@@ -8,6 +8,7 @@ use crate::annis::operator::BinaryOperator;
 use crate::annis::operator::BinaryOperatorSpec;
 use crate::annis::types::{AnnoKeyID, Component, ComponentType};
 use std::sync::Arc;
+use std::collections::HashSet;
 
 #[derive(Clone, Debug, PartialOrd, Ord, Hash, PartialEq, Eq)]
 pub struct LeftAlignmentSpec;
@@ -29,9 +30,10 @@ lazy_static! {
 }
 
 impl BinaryOperatorSpec for LeftAlignmentSpec {
-    fn necessary_components(&self, db: &Graph) -> Vec<Component> {
-        let mut v: Vec<Component> = vec![COMPONENT_LEFT.clone()];
-        v.append(&mut token_helper::necessary_components(db));
+    fn necessary_components(&self, db: &Graph) -> HashSet<Component> {
+        let mut v = HashSet::default();
+        v.insert(COMPONENT_LEFT.clone());
+        v.extend(token_helper::necessary_components(db));
         v
     }
 

--- a/src/annis/db/aql/operators/leftalignment.rs
+++ b/src/annis/db/aql/operators/leftalignment.rs
@@ -29,9 +29,9 @@ lazy_static! {
 }
 
 impl BinaryOperatorSpec for LeftAlignmentSpec {
-    fn necessary_components(&self, _db: &Graph) -> Vec<Component> {
+    fn necessary_components(&self, db: &Graph) -> Vec<Component> {
         let mut v: Vec<Component> = vec![COMPONENT_LEFT.clone()];
-        v.append(&mut token_helper::necessary_components());
+        v.append(&mut token_helper::necessary_components(db));
         v
     }
 

--- a/src/annis/db/aql/operators/near.rs
+++ b/src/annis/db/aql/operators/near.rs
@@ -7,10 +7,10 @@ use crate::annis::operator::EstimationType;
 use crate::annis::operator::{BinaryOperator, BinaryOperatorSpec};
 use crate::annis::types::{AnnoKeyID, Component, ComponentType};
 
-use std;
-use std::sync::Arc;
-use std::collections::HashSet;
 use rustc_hash::FxHashSet;
+use std;
+use std::collections::HashSet;
+use std::sync::Arc;
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct NearSpec {
@@ -21,27 +21,8 @@ pub struct NearSpec {
 #[derive(Clone)]
 struct Near {
     gs_order: Arc<GraphStorage>,
-    gs_left: Arc<GraphStorage>,
-    gs_right: Arc<GraphStorage>,
     tok_helper: TokenHelper,
     spec: NearSpec,
-}
-
-lazy_static! {
-    static ref COMPONENT_LEFT: Component = {
-        Component {
-            ctype: ComponentType::LeftToken,
-            layer: String::from("annis"),
-            name: String::from(""),
-        }
-    };
-    static ref COMPONENT_RIGHT: Component = {
-        Component {
-            ctype: ComponentType::RightToken,
-            layer: String::from("annis"),
-            name: String::from(""),
-        }
-    };
 }
 
 impl BinaryOperatorSpec for NearSpec {
@@ -57,8 +38,6 @@ impl BinaryOperatorSpec for NearSpec {
 
         let mut v = HashSet::default();
         v.insert(component_order.clone());
-        v.insert(COMPONENT_LEFT.clone());
-        v.insert(COMPONENT_RIGHT.clone());
         v.extend(token_helper::necessary_components(db));
         v
     }
@@ -95,15 +74,11 @@ impl Near {
         };
 
         let gs_order = db.get_graphstorage(&component_order)?;
-        let gs_left = db.get_graphstorage(&COMPONENT_LEFT)?;
-        let gs_right = db.get_graphstorage(&COMPONENT_RIGHT)?;
 
         let tok_helper = TokenHelper::new(db)?;
 
         Some(Near {
             gs_order,
-            gs_left,
-            gs_right,
             tok_helper,
             spec,
         })
@@ -130,7 +105,7 @@ impl BinaryOperator for Near {
             self.tok_helper.left_token_for(lhs.node)
         };
 
-        let it_forward : Box<Iterator<Item=u64>> = if let Some(start) = start_forward {
+        let it_forward: Box<Iterator<Item = u64>> = if let Some(start) = start_forward {
             let it = self
                 .gs_order
                 // get all token in the range
@@ -138,7 +113,7 @@ impl BinaryOperator for Near {
                 .fuse()
                 // find all left aligned nodes for this token and add it together with the token itself
                 .flat_map(move |t| {
-                    let it_aligned = self.gs_left.get_ingoing_edges(t);
+                    let it_aligned = self.tok_helper.get_gs_left_token().get_ingoing_edges(t);
                     std::iter::once(t).chain(it_aligned)
                 });
             Box::new(it)
@@ -146,7 +121,7 @@ impl BinaryOperator for Near {
             Box::new(std::iter::empty::<u64>())
         };
 
-        let it_backward : Box<Iterator<Item=u64>> = if let Some(start) = start_backward {
+        let it_backward: Box<Iterator<Item = u64>> = if let Some(start) = start_backward {
             let it = self
                 .gs_order
                 // get all token in the range
@@ -154,7 +129,7 @@ impl BinaryOperator for Near {
                 .fuse()
                 // find all right aligned nodes for this token and add it together with the token itself
                 .flat_map(move |t| {
-                    let it_aligned = self.gs_right.get_ingoing_edges(t);
+                    let it_aligned = self.tok_helper.get_gs_right_token_().get_ingoing_edges(t);
                     std::iter::once(t).chain(it_aligned)
                 });
             Box::new(it)
@@ -196,7 +171,6 @@ impl BinaryOperator for Near {
             }
             (start.unwrap(), end.unwrap())
         };
-
 
         self.gs_order.is_connected(
             &start_end_forward.0,

--- a/src/annis/db/aql/operators/near.rs
+++ b/src/annis/db/aql/operators/near.rs
@@ -44,7 +44,7 @@ lazy_static! {
 }
 
 impl BinaryOperatorSpec for NearSpec {
-    fn necessary_components(&self, _db: &Graph) -> Vec<Component> {
+    fn necessary_components(&self, db: &Graph) -> Vec<Component> {
         let component_order = Component {
             ctype: ComponentType::Ordering,
             layer: String::from("annis"),
@@ -59,7 +59,7 @@ impl BinaryOperatorSpec for NearSpec {
             COMPONENT_LEFT.clone(),
             COMPONENT_RIGHT.clone(),
         ];
-        v.append(&mut token_helper::necessary_components());
+        v.append(&mut token_helper::necessary_components(db));
         v
     }
 

--- a/src/annis/db/aql/operators/near.rs
+++ b/src/annis/db/aql/operators/near.rs
@@ -9,6 +9,7 @@ use crate::annis::types::{AnnoKeyID, Component, ComponentType};
 
 use std;
 use std::sync::Arc;
+use std::collections::HashSet;
 use rustc_hash::FxHashSet;
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
@@ -44,7 +45,7 @@ lazy_static! {
 }
 
 impl BinaryOperatorSpec for NearSpec {
-    fn necessary_components(&self, db: &Graph) -> Vec<Component> {
+    fn necessary_components(&self, db: &Graph) -> HashSet<Component> {
         let component_order = Component {
             ctype: ComponentType::Ordering,
             layer: String::from("annis"),
@@ -54,12 +55,11 @@ impl BinaryOperatorSpec for NearSpec {
                 .unwrap_or_else(|| String::from("")),
         };
 
-        let mut v: Vec<Component> = vec![
-            component_order.clone(),
-            COMPONENT_LEFT.clone(),
-            COMPONENT_RIGHT.clone(),
-        ];
-        v.append(&mut token_helper::necessary_components(db));
+        let mut v = HashSet::default();
+        v.insert(component_order.clone());
+        v.insert(COMPONENT_LEFT.clone());
+        v.insert(COMPONENT_RIGHT.clone());
+        v.extend(token_helper::necessary_components(db));
         v
     }
 

--- a/src/annis/db/aql/operators/overlap.rs
+++ b/src/annis/db/aql/operators/overlap.rs
@@ -9,6 +9,7 @@ use rustc_hash::FxHashSet;
 
 use std;
 use std::sync::Arc;
+use std::collections::HashSet;
 
 #[derive(Clone, Debug, PartialOrd, Ord, Hash, PartialEq, Eq)]
 pub struct OverlapSpec;
@@ -38,12 +39,11 @@ lazy_static! {
 }
 
 impl BinaryOperatorSpec for OverlapSpec {
-    fn necessary_components(&self, db: &Graph) -> Vec<Component> {
-        let mut v: Vec<Component> = vec![
-            COMPONENT_ORDER.clone(),
-            COMPONENT_COVERAGE.clone(),
-        ];
-        v.append(&mut token_helper::necessary_components(db));
+    fn necessary_components(&self, db: &Graph) -> HashSet<Component> {
+        let mut v = HashSet::default();
+        v.insert(COMPONENT_ORDER.clone());
+        v.insert(COMPONENT_COVERAGE.clone());
+        v.extend(token_helper::necessary_components(db));
         v
     }
 

--- a/src/annis/db/aql/operators/overlap.rs
+++ b/src/annis/db/aql/operators/overlap.rs
@@ -8,8 +8,8 @@ use crate::annis::types::{AnnoKeyID, Component, ComponentType, NodeID};
 use rustc_hash::FxHashSet;
 
 use std;
-use std::sync::Arc;
 use std::collections::HashSet;
+use std::sync::Arc;
 
 #[derive(Clone, Debug, PartialOrd, Ord, Hash, PartialEq, Eq)]
 pub struct OverlapSpec;
@@ -17,7 +17,7 @@ pub struct OverlapSpec;
 #[derive(Clone)]
 pub struct Overlap {
     gs_order: Arc<GraphStorage>,
-    gs_cov: Arc<GraphStorage>,
+    gs_cov: Vec<Arc<GraphStorage>>,
     tok_helper: TokenHelper,
 }
 
@@ -29,20 +29,13 @@ lazy_static! {
             name: String::from(""),
         }
     };
-    static ref COMPONENT_COVERAGE: Component = {
-        Component {
-            ctype: ComponentType::Coverage,
-            layer: String::from("annis"),
-            name: String::from(""),
-        }
-    };
 }
 
 impl BinaryOperatorSpec for OverlapSpec {
     fn necessary_components(&self, db: &Graph) -> HashSet<Component> {
         let mut v = HashSet::default();
         v.insert(COMPONENT_ORDER.clone());
-        v.insert(COMPONENT_COVERAGE.clone());
+        v.extend(db.get_all_components(Some(ComponentType::Coverage), None));
         v.extend(token_helper::necessary_components(db));
         v
     }
@@ -60,7 +53,12 @@ impl BinaryOperatorSpec for OverlapSpec {
 impl Overlap {
     pub fn new(db: &Graph) -> Option<Overlap> {
         let gs_order = db.get_graphstorage(&COMPONENT_ORDER)?;
-        let gs_cov = db.get_graphstorage(&COMPONENT_COVERAGE)?;
+        let mut gs_cov = Vec::default();
+        for c in db.get_all_components(Some(ComponentType::Coverage), None) {
+            if let Some(gs) = db.get_graphstorage(&c) {
+                gs_cov.push(gs);
+            }
+        }
 
         let tok_helper = TokenHelper::new(db)?;
 
@@ -83,28 +81,28 @@ impl BinaryOperator for Overlap {
         // use set to filter out duplicates
         let mut result = FxHashSet::default();
 
-        let covered: Box<Iterator<Item = NodeID>> = if self.tok_helper.is_token(lhs.node) {
-            Box::new(std::iter::once(lhs.node))
-        } else {
-            // all covered token
-            Box::new(
-                self.gs_cov
-                    .find_connected(lhs.node, 1, std::ops::Bound::Included(1))
-                    .fuse(),
-            )
-        };
+        let lhs_is_token = self.tok_helper.is_token(lhs.node);
 
-        for t in covered {
-            // get all nodes that are covering the token
-            for n in self
-                .gs_cov
-                .find_connected_inverse(t, 1, std::ops::Bound::Included(1))
-                .fuse()
-            {
-                result.insert(n);
+        for gs_cov in self.gs_cov.iter() {
+            let covered: Box<Iterator<Item = NodeID>> = if lhs_is_token {
+                Box::new(std::iter::once(lhs.node))
+            } else {
+                // all covered token
+                Box::new(
+                    gs_cov
+                        .find_connected(lhs.node, 1, std::ops::Bound::Included(1))
+                        .fuse(),
+                )
+            };
+
+            for t in covered {
+                // get all nodes that are covering the token
+                for n in gs_cov.get_ingoing_edges(t) {
+                    result.insert(n);
+                }
+                // also add the token itself
+                result.insert(t);
             }
-            // also add the token itself
-            result.insert(t);
         }
 
         Box::new(result.into_iter().map(|n| Match {
@@ -141,22 +139,29 @@ impl BinaryOperator for Overlap {
     }
 
     fn estimation_type(&self) -> EstimationType {
-        if let (Some(stats_cov), Some(stats_order)) = (
-            self.gs_cov.get_statistics(),
-            self.gs_order.get_statistics(),
-        ) {
+        if let Some(stats_order) = self.gs_order.get_statistics() {
+            let mut sum_included = 0;
+            let mut sum_cov_nodes = 0;
+
             let num_of_token = stats_order.nodes as f64;
-            if stats_cov.nodes == 0 {
+
+            for gs_cov in self.gs_cov.iter() {
+                if let Some(stats_cov) = gs_cov.get_statistics() {
+                    sum_cov_nodes += stats_cov.nodes;
+                    let covered_token_per_node = stats_cov.fan_out_99_percentile;
+                    // for each covered token get the number of inverse covered non-token nodes
+                    let aligned_non_token =
+                        covered_token_per_node * (stats_cov.inverse_fan_out_99_percentile);
+
+                    sum_included += covered_token_per_node + aligned_non_token;
+                }
+            }
+
+            if sum_cov_nodes == 0 {
                 // only token in this corpus
                 return EstimationType::SELECTIVITY(1.0 / num_of_token);
             } else {
-                let covered_token_per_node: f64 = stats_cov.fan_out_99_percentile as f64;
-                // for each covered token get the number of inverse covered non-token nodes
-                let aligned_non_token: f64 =
-                    covered_token_per_node * (stats_cov.inverse_fan_out_99_percentile as f64);
-
-                let sum_included = covered_token_per_node + aligned_non_token;
-                return EstimationType::SELECTIVITY(sum_included / (stats_cov.nodes as f64));
+                return EstimationType::SELECTIVITY(sum_included as f64 / (sum_cov_nodes as f64));
             }
         }
 

--- a/src/annis/db/aql/operators/overlap.rs
+++ b/src/annis/db/aql/operators/overlap.rs
@@ -53,13 +53,11 @@ impl BinaryOperatorSpec for OverlapSpec {
 impl Overlap {
     pub fn new(db: &Graph) -> Option<Overlap> {
         let gs_order = db.get_graphstorage(&COMPONENT_ORDER)?;
-        let mut gs_cov = Vec::default();
-        for c in db.get_all_components(Some(ComponentType::Coverage), None) {
-            if let Some(gs) = db.get_graphstorage(&c) {
-                gs_cov.push(gs);
-            }
-        }
-
+        let gs_cov: Vec<Arc<GraphStorage>> = db
+            .get_all_components(Some(ComponentType::Coverage), None)
+            .into_iter()
+            .filter_map(|c| db.get_graphstorage(&c))
+            .collect();
         let tok_helper = TokenHelper::new(db)?;
 
         Some(Overlap {

--- a/src/annis/db/aql/operators/overlap.rs
+++ b/src/annis/db/aql/operators/overlap.rs
@@ -38,12 +38,12 @@ lazy_static! {
 }
 
 impl BinaryOperatorSpec for OverlapSpec {
-    fn necessary_components(&self, _db: &Graph) -> Vec<Component> {
+    fn necessary_components(&self, db: &Graph) -> Vec<Component> {
         let mut v: Vec<Component> = vec![
             COMPONENT_ORDER.clone(),
             COMPONENT_COVERAGE.clone(),
         ];
-        v.append(&mut token_helper::necessary_components());
+        v.append(&mut token_helper::necessary_components(db));
         v
     }
 

--- a/src/annis/db/aql/operators/overlap.rs
+++ b/src/annis/db/aql/operators/overlap.rs
@@ -57,6 +57,13 @@ impl Overlap {
             .get_all_components(Some(ComponentType::Coverage), None)
             .into_iter()
             .filter_map(|c| db.get_graphstorage(&c))
+            .filter(|gs| {
+                if let Some(stats) = gs.get_statistics() {
+                    stats.nodes > 0
+                } else {
+                    true
+                }
+            })
             .collect();
         let tok_helper = TokenHelper::new(db)?;
 

--- a/src/annis/db/aql/operators/precedence.rs
+++ b/src/annis/db/aql/operators/precedence.rs
@@ -8,7 +8,7 @@ use crate::annis::operator::{BinaryOperator, BinaryOperatorSpec};
 use crate::annis::types::{AnnoKeyID, Component, ComponentType};
 
 use std;
-use std::collections::VecDeque;
+use std::collections::{HashSet, VecDeque};
 use std::sync::Arc;
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord)]
@@ -43,7 +43,7 @@ lazy_static! {
 }
 
 impl BinaryOperatorSpec for PrecedenceSpec {
-    fn necessary_components(&self, db: &Graph) -> Vec<Component> {
+    fn necessary_components(&self, db: &Graph) -> HashSet<Component> {
         let component_order = Component {
             ctype: ComponentType::Ordering,
             layer: String::from("annis"),
@@ -53,12 +53,11 @@ impl BinaryOperatorSpec for PrecedenceSpec {
                 .unwrap_or_else(|| String::from("")),
         };
 
-        let mut v: Vec<Component> = vec![
-            component_order.clone(),
-            COMPONENT_LEFT.clone(),
-            COMPONENT_RIGHT.clone(),
-        ];
-        v.append(&mut token_helper::necessary_components(db));
+        let mut v = HashSet::default();
+        v.insert(component_order.clone());
+        v.insert(COMPONENT_LEFT.clone());
+        v.insert(COMPONENT_RIGHT.clone());
+        v.extend(token_helper::necessary_components(db));
         v
     }
 

--- a/src/annis/db/aql/operators/precedence.rs
+++ b/src/annis/db/aql/operators/precedence.rs
@@ -43,7 +43,7 @@ lazy_static! {
 }
 
 impl BinaryOperatorSpec for PrecedenceSpec {
-    fn necessary_components(&self, _db: &Graph) -> Vec<Component> {
+    fn necessary_components(&self, db: &Graph) -> Vec<Component> {
         let component_order = Component {
             ctype: ComponentType::Ordering,
             layer: String::from("annis"),
@@ -58,7 +58,7 @@ impl BinaryOperatorSpec for PrecedenceSpec {
             COMPONENT_LEFT.clone(),
             COMPONENT_RIGHT.clone(),
         ];
-        v.append(&mut token_helper::necessary_components());
+        v.append(&mut token_helper::necessary_components(db));
         v
     }
 

--- a/src/annis/db/aql/operators/rightalignment.rs
+++ b/src/annis/db/aql/operators/rightalignment.rs
@@ -1,13 +1,11 @@
-use crate::annis::operator::EstimationType;
-use crate::annis::db::graphstorage::GraphStorage;
 use crate::annis::db::token_helper;
 use crate::annis::db::token_helper::TokenHelper;
 use crate::annis::db::Graph;
 use crate::annis::db::Match;
 use crate::annis::operator::BinaryOperator;
 use crate::annis::operator::BinaryOperatorSpec;
-use crate::annis::types::{AnnoKeyID, Component, ComponentType};
-use std::sync::Arc;
+use crate::annis::operator::EstimationType;
+use crate::annis::types::{AnnoKeyID, Component};
 use std::collections::HashSet;
 
 #[derive(Clone, Debug, PartialOrd, Ord, Hash, PartialEq, Eq)]
@@ -15,24 +13,12 @@ pub struct RightAlignmentSpec;
 
 #[derive(Clone)]
 pub struct RightAlignment {
-    gs_right: Arc<GraphStorage>,
     tok_helper: TokenHelper,
-}
-
-lazy_static! {
-    static ref COMPONENT_RIGHT: Component = {
-        Component {
-            ctype: ComponentType::RightToken,
-            layer: String::from("annis"),
-            name: String::from(""),
-        }
-    };
 }
 
 impl BinaryOperatorSpec for RightAlignmentSpec {
     fn necessary_components(&self, db: &Graph) -> HashSet<Component> {
         let mut v = HashSet::default();
-        v.insert(COMPONENT_RIGHT.clone());
         v.extend(token_helper::necessary_components(db));
         v
     }
@@ -49,11 +35,9 @@ impl BinaryOperatorSpec for RightAlignmentSpec {
 
 impl RightAlignment {
     pub fn new(db: &Graph) -> Option<RightAlignment> {
-        let gs_right = db.get_graphstorage(&COMPONENT_RIGHT)?;
-
         let tok_helper = TokenHelper::new(db)?;
 
-        Some(RightAlignment { gs_right, tok_helper })
+        Some(RightAlignment { tok_helper })
     }
 }
 
@@ -64,8 +48,6 @@ impl std::fmt::Display for RightAlignment {
 }
 
 impl BinaryOperator for RightAlignment {
-    
-
     fn retrieve_matches(&self, lhs: &Match) -> Box<Iterator<Item = Match>> {
         let mut aligned = Vec::default();
 
@@ -74,7 +56,7 @@ impl BinaryOperator for RightAlignment {
                 node: lhs_token,
                 anno_key: AnnoKeyID::default(),
             });
-            aligned.extend(self.gs_right.get_ingoing_edges(lhs_token).map(|n| Match {
+            aligned.extend(self.tok_helper.get_gs_right_token_().get_ingoing_edges(lhs_token).map(|n| Match {
                 node: n,
                 anno_key: AnnoKeyID::default(),
             }));
@@ -103,9 +85,11 @@ impl BinaryOperator for RightAlignment {
     }
 
     fn estimation_type(&self) -> EstimationType {
-        if let Some(stats_right) = self.gs_right.get_statistics() {
+        if let Some(stats_right) = self.tok_helper.get_gs_right_token_().get_statistics() {
             let aligned_nodes_per_token: f64 = stats_right.inverse_fan_out_99_percentile as f64;
-            return EstimationType::SELECTIVITY(aligned_nodes_per_token / (stats_right.nodes as f64));
+            return EstimationType::SELECTIVITY(
+                aligned_nodes_per_token / (stats_right.nodes as f64),
+            );
         }
 
         EstimationType::SELECTIVITY(0.1)

--- a/src/annis/db/aql/operators/rightalignment.rs
+++ b/src/annis/db/aql/operators/rightalignment.rs
@@ -8,6 +8,7 @@ use crate::annis::operator::BinaryOperator;
 use crate::annis::operator::BinaryOperatorSpec;
 use crate::annis::types::{AnnoKeyID, Component, ComponentType};
 use std::sync::Arc;
+use std::collections::HashSet;
 
 #[derive(Clone, Debug, PartialOrd, Ord, Hash, PartialEq, Eq)]
 pub struct RightAlignmentSpec;
@@ -29,9 +30,10 @@ lazy_static! {
 }
 
 impl BinaryOperatorSpec for RightAlignmentSpec {
-    fn necessary_components(&self, db: &Graph) -> Vec<Component> {
-        let mut v: Vec<Component> = vec![COMPONENT_RIGHT.clone()];
-        v.append(&mut token_helper::necessary_components(db));
+    fn necessary_components(&self, db: &Graph) -> HashSet<Component> {
+        let mut v = HashSet::default();
+        v.insert(COMPONENT_RIGHT.clone());
+        v.extend(token_helper::necessary_components(db));
         v
     }
 

--- a/src/annis/db/aql/operators/rightalignment.rs
+++ b/src/annis/db/aql/operators/rightalignment.rs
@@ -29,9 +29,9 @@ lazy_static! {
 }
 
 impl BinaryOperatorSpec for RightAlignmentSpec {
-    fn necessary_components(&self, _db: &Graph) -> Vec<Component> {
+    fn necessary_components(&self, db: &Graph) -> Vec<Component> {
         let mut v: Vec<Component> = vec![COMPONENT_RIGHT.clone()];
-        v.append(&mut token_helper::necessary_components());
+        v.append(&mut token_helper::necessary_components(db));
         v
     }
 

--- a/src/annis/db/exec/nodesearch.rs
+++ b/src/annis/db/exec/nodesearch.rs
@@ -656,6 +656,13 @@ impl<'a> NodeSearch<'a> {
                 .get_all_components(Some(ComponentType::Coverage), None)
                 .into_iter()
                 .filter_map(|c| db.get_graphstorage(&c))
+                .filter(|gs| {
+                    if let Some(stats) = gs.get_statistics() {
+                        stats.nodes > 0
+                    } else {
+                        true
+                    }
+                })
                 .collect();
 
             let it = it_base.filter(move |n| {
@@ -757,6 +764,13 @@ impl<'a> NodeSearch<'a> {
                 .get_all_components(Some(ComponentType::Coverage), None)
                 .into_iter()
                 .filter_map(|c| db.get_graphstorage(&c))
+                .filter(|gs| {
+                    if let Some(stats) = gs.get_statistics() {
+                        stats.nodes > 0
+                    } else {
+                        true
+                    }
+                })
                 .collect();
 
             let filter_func: Box<Fn(&Match) -> bool + Send + Sync> = Box::new(move |m| {
@@ -851,6 +865,13 @@ impl<'a> NodeSearch<'a> {
             .get_all_components(Some(ComponentType::Coverage), None)
             .into_iter()
             .filter_map(|c| db.get_graphstorage(&c))
+            .filter(|gs| {
+                if let Some(stats) = gs.get_statistics() {
+                    stats.nodes > 0
+                } else {
+                    true
+                }
+            })
             .collect();
 
         let filter_func: Box<Fn(&Match) -> bool + Send + Sync> = Box::new(move |m| {

--- a/src/annis/db/exec/nodesearch.rs
+++ b/src/annis/db/exec/nodesearch.rs
@@ -82,9 +82,9 @@ impl NodeSearchSpec {
         }
     }
 
-    pub fn necessary_components(&self, _db: &Graph) -> Vec<Component> {
+    pub fn necessary_components(&self, db: &Graph) -> Vec<Component> {
         if let &NodeSearchSpec::AnyToken = &self {
-            return tokensearch::AnyTokenSearch::necessary_components();
+            return tokensearch::AnyTokenSearch::necessary_components(db);
         }
         vec![]
     }

--- a/src/annis/db/exec/nodesearch.rs
+++ b/src/annis/db/exec/nodesearch.rs
@@ -13,6 +13,7 @@ use regex;
 use std;
 use std::fmt;
 use std::sync::Arc;
+use std::collections::HashSet;
 
 /// An [ExecutionNode](#impl-ExecutionNode) which wraps base node (annotation) searches.
 pub struct NodeSearch<'a> {
@@ -82,11 +83,11 @@ impl NodeSearchSpec {
         }
     }
 
-    pub fn necessary_components(&self, db: &Graph) -> Vec<Component> {
+    pub fn necessary_components(&self, db: &Graph) -> HashSet<Component> {
         if let &NodeSearchSpec::AnyToken = &self {
             return tokensearch::AnyTokenSearch::necessary_components(db);
         }
-        vec![]
+        HashSet::default()
     }
 }
 
@@ -884,7 +885,7 @@ impl<'a> NodeSearch<'a> {
         db: &'a Graph,
         node_search_desc: Arc<NodeSearchDesc>,
         desc: Option<&Desc>,
-        components: Vec<Component>,
+        components: HashSet<Component>,
         edge_anno_spec: Option<EdgeAnnoSearchSpec>,
     ) -> Result<NodeSearch<'a>> {
         let node_search_desc_1 = node_search_desc.clone();

--- a/src/annis/db/exec/tokensearch.rs
+++ b/src/annis/db/exec/tokensearch.rs
@@ -51,8 +51,8 @@ impl<'a> AnyTokenSearch<'a> {
         })
     }
 
-    pub fn necessary_components() -> Vec<Component> {
-        let mut components = token_helper::necessary_components();
+    pub fn necessary_components(db: &Graph) -> Vec<Component> {
+        let mut components = token_helper::necessary_components(db);
         components.push(COMPONENT_ORDER.clone());
         components
     }

--- a/src/annis/db/exec/tokensearch.rs
+++ b/src/annis/db/exec/tokensearch.rs
@@ -12,6 +12,7 @@ use crate::annis::types::AnnoKeyID;
 use crate::annis::types::{Component, ComponentType, NodeID};
 
 use std::fmt;
+use std::collections::HashSet;
 
 /// An [ExecutionNode](#impl-ExecutionNode) which wraps the search for *all* token in a corpus.
 pub struct AnyTokenSearch<'a> {
@@ -51,9 +52,9 @@ impl<'a> AnyTokenSearch<'a> {
         })
     }
 
-    pub fn necessary_components(db: &Graph) -> Vec<Component> {
+    pub fn necessary_components(db: &Graph) -> HashSet<Component> {
         let mut components = token_helper::necessary_components(db);
-        components.push(COMPONENT_ORDER.clone());
+        components.insert(COMPONENT_ORDER.clone());
         components
     }
 

--- a/src/annis/db/mod.rs
+++ b/src/annis/db/mod.rs
@@ -891,6 +891,19 @@ impl Graph {
             }
         }
 
+        if let Ok(gs_cov) = self.get_or_create_writable(&Component {
+            ctype: ComponentType::Coverage,
+            name: "inherited-coverage".to_owned(),
+            layer: ANNIS_NS.to_owned(),
+        }) {
+            for t in covered_token.iter() {
+                gs_cov.add_edge(Edge {
+                    source: n,
+                    target: *t,
+                });
+            }
+        }
+
         covered_token
     }
 

--- a/src/annis/db/mod.rs
+++ b/src/annis/db/mod.rs
@@ -70,9 +70,9 @@ impl Match {
     }
 
     /// Returns true if this match is different to all the other matches given as argument.
-    /// 
+    ///
     /// A single match is different if the node ID or the annotation key are different.
-    pub fn different_to_all(&self, other : &Vec<Match>) -> bool {
+    pub fn different_to_all(&self, other: &Vec<Match>) -> bool {
         for o in other.iter() {
             if self.node == o.node && self.anno_key == o.anno_key {
                 return false;
@@ -82,9 +82,9 @@ impl Match {
     }
 
     /// Returns true if this match is different to the other match given as argument.
-    /// 
+    ///
     /// A single match is different if the node ID or the annotation key are different.
-    pub fn different_to(&self, other : &Match) -> bool {
+    pub fn different_to(&self, other: &Match) -> bool {
         self.node != other.node || self.anno_key != other.anno_key
     }
 }
@@ -603,7 +603,6 @@ impl Graph {
                 }
                 UpdateEvent::DeleteNode { node_name } => {
                     if let Some(existing_node_id) = self.get_node_id_from_name(&node_name) {
-
                         invalid_nodes.extend(self.get_parent_text_coverage_nodes(existing_node_id));
 
                         // delete all annotations
@@ -690,10 +689,9 @@ impl Graph {
                         self.get_node_id_from_name(&target_node),
                     ) {
                         if let Ok(ctype) = ComponentType::from_str(&component_type) {
-
                             invalid_nodes.extend(self.get_parent_text_coverage_nodes(source));
                             invalid_nodes.extend(self.get_parent_text_coverage_nodes(target));
-                            
+
                             let c = Component {
                                 ctype,
                                 layer,
@@ -701,7 +699,6 @@ impl Graph {
                             };
                             let gs = self.get_or_create_writable(&c)?;
                             gs.delete_edge(&Edge { source, target });
-
                         }
                     }
                 }
@@ -783,7 +780,7 @@ impl Graph {
             layer: ANNIS_NS.to_owned(),
             name: "".to_owned(),
         }) {
-            self.reindex_left_right_token(invalid_nodes, gs_order)?;
+            self.reindex_inherited_coverage(invalid_nodes, gs_order)?;
         }
 
         Ok(())
@@ -808,7 +805,7 @@ impl Graph {
         dfs.map(|step| step.node).collect()
     }
 
-    fn reindex_left_right_token(
+    fn reindex_inherited_coverage(
         &mut self,
         invalid_nodes: FxHashSet<NodeID>,
         gs_order: Arc<GraphStorage>,
@@ -834,6 +831,15 @@ impl Graph {
             for n in invalid_nodes.iter() {
                 gs_right.delete_node(n);
             }
+
+            let gs_cov = self.get_or_create_writable(&Component {
+                ctype: ComponentType::Coverage,
+                name: "inherited-coverage".to_owned(),
+                layer: ANNIS_NS.to_owned(),
+            })?;
+            for n in invalid_nodes.iter() {
+                gs_cov.delete_node(n);
+            }
         }
 
         // go over each node and calculate the left-most and right-most token
@@ -841,7 +847,51 @@ impl Graph {
             self.calculate_token_alignment(*n, ComponentType::LeftToken, gs_order.as_ref());
             self.calculate_token_alignment(*n, ComponentType::RightToken, gs_order.as_ref());
         }
+
+        if let Some(token_helper) = token_helper::TokenHelper::new(self) {
+            for n in invalid_nodes.iter() {
+                self.calculate_inherited_coverage_edges(*n, &token_helper);
+            }
+        }
+
         Ok(())
+    }
+
+    fn calculate_inherited_coverage_edges(
+        &mut self,
+        n: NodeID,
+        token_helper: &token_helper::TokenHelper,
+    ) -> FxHashSet<NodeID> {
+        let all_cov_gs: Vec<Arc<GraphStorage>> = self
+            .get_all_components(Some(ComponentType::Coverage), None)
+            .into_iter()
+            .filter_map(|c| self.get_graphstorage(&c))
+            .collect();
+
+        let mut covered_token = FxHashSet::default();
+        for gs in all_cov_gs.iter() {
+            covered_token.extend(gs.find_connected(n, 1, std::ops::Bound::Included(1)));
+        }
+
+        if covered_token.is_empty() {
+            if token_helper.is_token(n) {
+                covered_token.insert(n);
+            } else {
+                // recursivly get the covered token from all children connected by a dominance relation
+                for dom_component in
+                    self.get_all_components(Some(ComponentType::Dominance), Some(""))
+                {
+                    if let Some(dom_gs) = self.get_graphstorage(&dom_component) {
+                        for out in dom_gs.get_outgoing_edges(n) {
+                            covered_token
+                                .extend(self.calculate_inherited_coverage_edges(out, token_helper));
+                        }
+                    }
+                }
+            }
+        }
+
+        covered_token
     }
 
     fn calculate_token_alignment(
@@ -850,16 +900,17 @@ impl Graph {
         ctype: ComponentType,
         gs_order: &GraphStorage,
     ) -> Option<NodeID> {
-        let coverage_component = Component {
-            ctype: ComponentType::Coverage,
-            name: "".to_owned(),
-            layer: ANNIS_NS.to_owned(),
-        };
         let alignment_component = Component {
             ctype: ctype.clone(),
             name: "".to_owned(),
             layer: ANNIS_NS.to_owned(),
         };
+
+        let all_cov_gs: Vec<Arc<GraphStorage>> = self
+            .get_all_components(Some(ComponentType::Coverage), None)
+            .into_iter()
+            .filter_map(|c| self.get_graphstorage(&c))
+            .collect();
 
         // if this is a token, return the token itself
         if self
@@ -868,10 +919,15 @@ impl Graph {
             .is_some()
         {
             // also check if this is an actually token and not only a segmentation
-            if let Some(gs_coverage) = self.get_graphstorage(&coverage_component) {
-                if gs_coverage.get_outgoing_edges(n).next().is_none() {
-                    return Some(n);
+            let mut is_token = true;
+            for gs_coverage in all_cov_gs.iter() {
+                if gs_coverage.get_outgoing_edges(n).next().is_some() {
+                    is_token = false;
+                    break;
                 }
+            }
+            if is_token {
+                return Some(n);
             }
         }
 
@@ -889,7 +945,8 @@ impl Graph {
 
         let mut text_coverage_components =
             self.get_all_components(Some(ComponentType::Dominance), Some(""));
-        text_coverage_components.push(coverage_component.clone());
+        text_coverage_components
+            .extend(self.get_all_components(Some(ComponentType::Coverage), None));
         for c in text_coverage_components {
             if let Some(gs_for_component) = self.get_graphstorage(&c) {
                 for target in gs_for_component.get_outgoing_edges(n) {

--- a/src/annis/db/mod.rs
+++ b/src/annis/db/mod.rs
@@ -1314,17 +1314,33 @@ impl Graph {
         ctype: Option<ComponentType>,
         name: Option<&str>,
     ) -> Vec<Component> {
-        if let (Some(ctype), Some(name)) = (ctype.clone(), name) {
+        if let (Some(ctype), Some(name)) = (&ctype, name) {
             // lookup component from sorted map
             let mut result: Vec<Component> = Vec::new();
             let ckey = Component {
-                ctype,
+                ctype: ctype.clone(),
                 name: String::from(name),
-                layer: String::from(""),
+                layer: String::default(),
             };
 
             for (c, _) in self.components.range(ckey..) {
                 if c.name != name {
+                    break;
+                }
+                result.push(c.clone());
+            }
+            return result;
+        } else if let Some(ctype) = &ctype {
+            // lookup component from sorted map
+            let mut result: Vec<Component> = Vec::new();
+            let ckey = Component {
+                ctype: ctype.clone(),
+                name: String::default(),
+                layer: String::default(),
+            };
+
+            for (c, _) in self.components.range(ckey..) {
+                if c.ctype != *ctype {
                     break;
                 }
                 result.push(c.clone());

--- a/src/annis/db/query/conjunction.rs
+++ b/src/annis/db/query/conjunction.rs
@@ -19,8 +19,7 @@ use rand::distributions::Distribution;
 use rand::distributions::Uniform;
 use rand::SeedableRng;
 use rand_xorshift::XorShiftRng;
-use std::collections::BTreeMap;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet, BTreeMap};
 use std::iter::FromIterator;
 use std::sync::Arc;
 
@@ -348,17 +347,17 @@ impl<'a> Conjunction<'a> {
         .into());
     }
 
-    pub fn necessary_components(&self, db: &Graph) -> Vec<Component> {
-        let mut result = vec![];
+    pub fn necessary_components(&self, db: &Graph) -> HashSet<Component> {
+        let mut result = HashSet::default();
 
         for op_entry in &self.unary_operators {
-            let mut c = op_entry.op.necessary_components(db);
-            result.append(&mut c);
+            let c = op_entry.op.necessary_components(db);
+            result.extend(c);
         }
 
         for op_entry in &self.binary_operators {
-            let mut c = op_entry.op.necessary_components(db);
-            result.append(&mut c);
+            let c = op_entry.op.necessary_components(db);
+            result.extend(c);
         }
         for n in &self.nodes {
             result.extend(n.1.necessary_components(db));

--- a/src/annis/db/query/disjunction.rs
+++ b/src/annis/db/query/disjunction.rs
@@ -1,6 +1,7 @@
 use super::conjunction::Conjunction;
 use crate::annis::db::Graph;
 use crate::annis::types::Component;
+use std::collections::HashSet;
 
 pub struct Disjunction<'a> {
     pub alternatives: Vec<Conjunction<'a>>,
@@ -11,12 +12,12 @@ impl<'a> Disjunction<'a> {
         Disjunction { alternatives }
     }
 
-    pub fn necessary_components(&self, db: &Graph) -> Vec<Component> {
-        let mut result = vec![];
+    pub fn necessary_components(&self, db: &Graph) -> HashSet<Component> {
+        let mut result = HashSet::default();
 
         for alt in &self.alternatives {
-            let mut c = alt.necessary_components(db);
-            result.append(&mut c);
+            let c = alt.necessary_components(db);
+            result.extend(c);
         }
 
         result

--- a/src/annis/db/token_helper.rs
+++ b/src/annis/db/token_helper.rs
@@ -51,7 +51,15 @@ impl TokenHelper {
         let mut cov_edges = Vec::with_capacity(cov_components.len());
         for c in cov_components {
             if let Some(gs) = db.get_graphstorage(&c) {
-                cov_edges.push(gs);
+                let empty = if let Some(stats) = gs.get_statistics() {
+                    stats.nodes == 0
+                } else {
+                    false
+                };
+
+                if !empty {
+                    cov_edges.push(gs);
+                }
             }
         }
         Some(TokenHelper {

--- a/src/annis/db/token_helper.rs
+++ b/src/annis/db/token_helper.rs
@@ -47,21 +47,19 @@ pub fn necessary_components(db: &Graph) -> HashSet<Component> {
 
 impl TokenHelper {
     pub fn new(db: &Graph) -> Option<TokenHelper> {
-        let cov_components = db.get_all_components(Some(ComponentType::Coverage), None);
-        let mut cov_edges = Vec::with_capacity(cov_components.len());
-        for c in cov_components {
-            if let Some(gs) = db.get_graphstorage(&c) {
-                let empty = if let Some(stats) = gs.get_statistics() {
-                    stats.nodes == 0
+        let cov_edges: Vec<Arc<GraphStorage>> = db
+            .get_all_components(Some(ComponentType::Coverage), None)
+            .into_iter()
+            .filter_map(|c| db.get_graphstorage(&c))
+            .filter(|gs| {
+                if let Some(stats) = gs.get_statistics() {
+                    stats.nodes > 0
                 } else {
-                    false
-                };
-
-                if !empty {
-                    cov_edges.push(gs);
+                    true
                 }
-            }
-        }
+            })
+            .collect();
+            
         Some(TokenHelper {
             node_annos: db.node_annos.clone(),
             left_edges: db.get_graphstorage(&COMPONENT_LEFT)?,

--- a/src/annis/db/token_helper.rs
+++ b/src/annis/db/token_helper.rs
@@ -68,6 +68,17 @@ impl TokenHelper {
             tok_key: db.node_annos.get_key_id(&db.get_token_key())?,
         })
     }
+    pub fn get_gs_coverage(&self) -> &Vec<Arc<GraphStorage>> {
+        &self.cov_edges
+    }
+
+    pub fn get_gs_left_token(&self) -> &GraphStorage {
+        self.left_edges.as_ref()
+    }
+
+    pub fn get_gs_right_token_(&self) -> &GraphStorage {
+        self.right_edges.as_ref()
+    }
 
     pub fn is_token(&self, id: NodeID) -> bool {
         if self

--- a/src/annis/db/token_helper.rs
+++ b/src/annis/db/token_helper.rs
@@ -10,7 +10,7 @@ pub struct TokenHelper {
     node_annos: Arc<AnnoStorage<NodeID>>,
     left_edges: Arc<GraphStorage>,
     right_edges: Arc<GraphStorage>,
-    cov_edges: Option<Arc<GraphStorage>>,
+    cov_edges: Vec<Arc<GraphStorage>>,
     tok_key: usize,
 }
 
@@ -29,46 +29,53 @@ lazy_static! {
             name: String::from(""),
         }
     };
-    static ref COMPONENT_COV: Component = {
-        Component {
-            ctype: ComponentType::Coverage,
-            layer: String::from("annis"),
-            name: String::from(""),
-        }
-    };
 }
 
-pub fn necessary_components() -> Vec<Component> {
-    vec![
-        COMPONENT_LEFT.clone(),
-        COMPONENT_RIGHT.clone(),
-        COMPONENT_COV.clone(),
-    ]
+pub fn necessary_components(db: &Graph) -> Vec<Component> {
+    let mut result = vec![COMPONENT_LEFT.clone(), COMPONENT_RIGHT.clone()];
+    // we need all coverage components
+    result.extend(
+        db.get_all_components(Some(ComponentType::Coverage), None)
+            .into_iter(),
+    );
+
+    result
 }
 
 impl TokenHelper {
     pub fn new(db: &Graph) -> Option<TokenHelper> {
+        let cov_components = db.get_all_components(Some(ComponentType::Coverage), None);
+        let mut cov_edges = Vec::with_capacity(cov_components.len());
+        for c in cov_components {
+            if let Some(gs) = db.get_graphstorage(&c) {
+                cov_edges.push(gs);
+            }
+        }
         Some(TokenHelper {
             node_annos: db.node_annos.clone(),
             left_edges: db.get_graphstorage(&COMPONENT_LEFT)?,
             right_edges: db.get_graphstorage(&COMPONENT_RIGHT)?,
-            cov_edges: db.get_graphstorage(&COMPONENT_COV),
+            cov_edges,
             tok_key: db.node_annos.get_key_id(&db.get_token_key())?,
         })
     }
 
     pub fn is_token(&self, id: NodeID) -> bool {
-        self.node_annos
+        if self
+            .node_annos
             .get_value_for_item_by_id(&id, self.tok_key)
             .is_some()
-            && self.cov_edges.is_some()
-            && self
-                .cov_edges
-                .as_ref()
-                .unwrap()
-                .get_outgoing_edges(id)
-                .next()
-                .is_none()
+        {
+            // check if there is no outgoing edge in any of the coverage components
+            for c in self.cov_edges.iter() {
+                if c.get_outgoing_edges(id).next().is_some() {
+                    return false;
+                }
+            }
+            return true;
+        } else {
+            return false;
+        }
     }
 
     pub fn right_token_for(&self, n: NodeID) -> Option<NodeID> {

--- a/src/annis/db/token_helper.rs
+++ b/src/annis/db/token_helper.rs
@@ -4,6 +4,7 @@ use crate::annis::db::Graph;
 use crate::annis::types::{Component, ComponentType, NodeID};
 
 use std::sync::Arc;
+use std::collections::HashSet;
 
 #[derive(Clone)]
 pub struct TokenHelper {
@@ -31,8 +32,10 @@ lazy_static! {
     };
 }
 
-pub fn necessary_components(db: &Graph) -> Vec<Component> {
-    let mut result = vec![COMPONENT_LEFT.clone(), COMPONENT_RIGHT.clone()];
+pub fn necessary_components(db: &Graph) -> HashSet<Component> {
+    let mut result = HashSet::default();
+    result.insert(COMPONENT_LEFT.clone());
+    result.insert(COMPONENT_RIGHT.clone());
     // we need all coverage components
     result.extend(
         db.get_all_components(Some(ComponentType::Coverage), None)

--- a/src/annis/operator.rs
+++ b/src/annis/operator.rs
@@ -2,6 +2,7 @@ use crate::annis::db::AnnotationStorage;
 use crate::annis::db::{Graph, Match};
 use crate::annis::types::{Component, Edge};
 use std;
+use std::collections::HashSet;
 
 #[derive(Clone, Debug, PartialOrd, Ord, Hash, PartialEq, Eq)]
 pub enum EdgeAnnoSearchSpec {
@@ -162,7 +163,7 @@ pub trait BinaryOperator: std::fmt::Display + Send + Sync {
 }
 
 pub trait BinaryOperatorSpec: std::fmt::Debug {
-    fn necessary_components(&self, db: &Graph) -> Vec<Component>;
+    fn necessary_components(&self, db: &Graph) -> HashSet<Component>;
 
     fn create_operator(&self, db: &Graph) -> Option<Box<BinaryOperator>>;
 
@@ -177,7 +178,7 @@ pub trait BinaryOperatorSpec: std::fmt::Debug {
 }
 
 pub trait UnaryOperatorSpec: std::fmt::Debug {
-    fn necessary_components(&self, db: &Graph) -> Vec<Component>;
+    fn necessary_components(&self, db: &Graph) -> HashSet<Component>;
 
     fn create_operator(&self, db: &Graph) -> Option<Box<UnaryOperator>>;
 }


### PR DESCRIPTION
The `Coverage` components are used to connect spans to their tokens. Additional, each node inherits the coverage edges from its children if it is connected with it via edges of a `Dominance` component. This inherited coverage edges allow faster access to. This information is redundant since it can be calculated by finding all reachable tokens of a node on the combined  `Dominance` and `Coverage` components 

Until now, users have to add the inherited edges by their-self when adding nodes to the graph. This update changes the behavior and the edges of the inherited `Coverage`  component are automatically calculated whenever the `applyUpdates()` method is called on the annotation graph (or the `CorpusStorage`). A benefit is that the "external" data model of graphANNIS is now much more similar to the one of Salt (especially with the previous removal of the inversed coverage component in #42  and the automatic generation of the `LeftToken`/`RightToken` compoents) and that it is easier to map annotation graph to graphANNIS in your own code.