### PR TITLE
Deprecate "meta::" search and allow it only in quirks mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased] - ReleaseDate
+
+### Changed
+
+- `meta::` queries are no deprecated and can only be used in quirks mode
+
 ## [0.19.4] - 2019-05-10
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 
-### Changed
+### Deprecated
 
 - `meta::` queries are no deprecated and can only be used in quirks mode
 

--- a/src/annis/db/aql/mod.rs
+++ b/src/annis/db/aql/mod.rs
@@ -32,8 +32,6 @@ fn map_conjunction<'a>(
 
     let mut pos_to_endpos: BTreeMap<usize, usize> = BTreeMap::default();
 
-    let mut legacy_meta_search: Vec<(NodeSearchSpec, ast::Pos)> = Vec::new();
-
     for literal in &c {
         match literal {
             ast::Literal::NodeSearch {
@@ -73,8 +71,20 @@ fn map_conjunction<'a>(
             ast::Literal::UnaryOp { .. } => {
                 // can only have node reference, not a literal
             }
-            ast::Literal::LegacyMetaSearch { spec, pos } => {
-                legacy_meta_search.push((spec.clone(), pos.clone()));
+            ast::Literal::LegacyMetaSearch { pos, .. } => {
+                if !quirks_mode {
+                    let start = get_line_and_column_for_pos(pos.start, &offsets);
+                    let end = if let Some(end_pos) = pos_to_endpos.get(&pos.end) {
+                        Some(get_line_and_column_for_pos(*end_pos, &offsets))
+                    } else {
+                        None
+                    };
+                    return Err(Error::AQLSyntaxError {
+                        desc: "Legacy metadata search is no longer allowed. Use the @* operator and normal attribute search instead.".into(),
+                        location: Some(LineColumnRange {start, end}),
+                    }
+                    .into());
+                }
             }
         };
     }
@@ -93,7 +103,12 @@ fn map_conjunction<'a>(
             None
         };
 
-        let idx = q.add_node_from_query(node_spec, variable, Some(LineColumnRange { start, end }), true);
+        let idx = q.add_node_from_query(
+            node_spec,
+            variable,
+            Some(LineColumnRange { start, end }),
+            true,
+        );
         pos_to_node_id.insert(start_pos, idx.clone());
         if first_node_pos.is_none() {
             first_node_pos = Some(idx);
@@ -119,12 +134,6 @@ fn map_conjunction<'a>(
 
             q.add_unary_operator_from_query(make_unary_operator_spec(op.clone()), &var, op_pos)?;
         }
-    }
-
-    // in quirks mode, all legacy metadata constraints are applied to all conjunctions
-    if !quirks_mode {
-        // add all legacy meta searches
-        add_legacy_metadata_constraints(&mut q, legacy_meta_search, first_node_pos)?;
     }
 
     let mut num_pointing_or_dominance_joins: HashMap<String, usize> = HashMap::default();
@@ -261,7 +270,7 @@ fn add_legacy_metadata_constraints(
                     },
                     None,
                     None,
-                    false
+                    false,
                 );
                 q.add_operator(
                     Box::new(IdenticalNodeSpec {}),
@@ -496,7 +505,7 @@ fn extract_location<'a>(
                 end: Some(end),
             })
         }
-        ParseError::UnrecognizedEOF {..} => {
+        ParseError::UnrecognizedEOF { .. } => {
             // set to end of query
             let start = get_line_and_column_for_pos(input.len() - 1, &offsets);
             Some(LineColumnRange { start, end: None })

--- a/src/annis/db/aql/mod.rs
+++ b/src/annis/db/aql/mod.rs
@@ -74,11 +74,7 @@ fn map_conjunction<'a>(
             ast::Literal::LegacyMetaSearch { pos, .. } => {
                 if !quirks_mode {
                     let start = get_line_and_column_for_pos(pos.start, &offsets);
-                    let end = if let Some(end_pos) = pos_to_endpos.get(&pos.end) {
-                        Some(get_line_and_column_for_pos(*end_pos, &offsets))
-                    } else {
-                        None
-                    };
+                    let end = Some(get_line_and_column_for_pos(pos.start + "meta::".len()-1, &offsets));
                     return Err(Error::AQLSyntaxError {
                         desc: "Legacy metadata search is no longer allowed. Use the @* operator and normal attribute search instead.".into(),
                         location: Some(LineColumnRange {start, end}),

--- a/tests/searchtest_queries.csv
+++ b/tests/searchtest_queries.csv
@@ -1,5 +1,5 @@
 name,aql,corpus,count
-noun_with_metadata,"pos=""NN"" & @* type=""interview"" _ident_ doc=/.*_ants/",GUM,126
+noun_with_metadata,"pos=""NN"" @* type=""interview"" _ident_ doc=/.*_ants/",GUM,126
 city,"lemma=""city"" _o_ entity ->coref[type=""coref""] entity",GUM,64
 coffee,"infstat=""giv"" & entity=""object"" & ""Coffee"" & #1 _o_#3 & #2 _o_ #3",GUM,1
 kind_dom_kind,"kind >[relname=""evidence""] kind",GUM,56

--- a/tests/searchtest_queries.csv
+++ b/tests/searchtest_queries.csv
@@ -1,5 +1,5 @@
 name,aql,corpus,count
-noun_with_metadata,"pos=""NN"" & meta::type=""interview"" & meta::doc=/.*_ants/",GUM,126
+noun_with_metadata,"pos=""NN"" & @* type=""interview"" _ident_ doc=/.*_ants/",GUM,126
 city,"lemma=""city"" _o_ entity ->coref[type=""coref""] entity",GUM,64
 coffee,"infstat=""giv"" & entity=""object"" & ""Coffee"" & #1 _o_#3 & #2 _o_ #3",GUM,1
 kind_dom_kind,"kind >[relname=""evidence""] kind",GUM,56
@@ -14,10 +14,10 @@ VV_dep,"pos=/VV.*/ ->dep[func=""nsubj""] tok & tok & #1 ->dep[func=""dobj""] #3"
 tok_dep_tok,"tok ->dep[func=""dep""] tok",GUM,246
 nonexisting_dep,"tok=""'s"" ->dep[func=""nsubjpass""]tok",GUM,0
 dep_xcomp,"""easy"" & ""measure"" & #1 ->dep[func=""xcomp""] #2",GUM,1
-meta_interview,"pos=""RB"" & meta::type=""interview""",GUM,522
+meta_interview,"pos=""RB"" @* type=""interview""",GUM,522
 Profile,"node ->dep[func=""nsubj""] node",GUM,3070
 DirectPointingWithAnno,"pos=""JJ"" ->dep[func=""cop""] ""is""",GUM,112
-NotDocument,"tok & meta::doc!=""maz-11299""",pcc2.1,34709
+NotDocument,"tok @* doc!=""maz-11299""",pcc2.1,34709
 StructureInclusionSeed,"cat=""S"" _i_ cat=""AP""",pcc2.1,726
 IsConnectedRange,"""Jugendlichen"" .3,10 ""Musikcafé""",pcc2.1,1
 Regex,cat=/.P/ >* /A.*/,pcc2.1,1130


### PR DESCRIPTION
GraphANNIS has now a much more flexible internal data model, where edges can occur between all nodes of a corpus, not only between nodes in the same document. In fact, documents don't really exists anymore, but nodes are connected to corpus structure nodes via edges of the type "PartOf" (https://korpling.github.io/graphANNIS/docs/v0.19/annotation-graph.html#corpus-structure).


The old `meta::` search was always limited to metadata from the documents and there was no good way of generalizing it to "include corpus metadata or subcorpus metadata" or to add metadata to texts .  The new `@` operator allows us to support such use cases, by filtering all nodes using paths on of edges with type "PartOf" and not distinguishing between "normal" annotation attributes and the ones attached to (sub-) corpus/documents . As the dominance and pointing relation operators, it has a range specifier part. E.g.
```
tok & meta::year=/195./
```
would become
```
tok @* year=/195./
```
for queries where all metadata (even the ones from the top-level corpus) should be included or
```
tok @ year=/195./
```
A specific distance (e.g. document or sub-corpus) can be defined as well:
```
tok @2,3 year=/195./
```

For using the complete flexibility, the user has to understand how the corpus hierarchy is modeled (e.g. are there text corpus nodes or not). But in general users can just replace "just replace meta::" with the `@*` operator to find any metadata. 

The legacy metadata search is still supported and emulated in the quirks mode, but to allow progress and more flexible corpus structures in the future I propose to disable it in the default AQL mode. This means that using `meta::`  is a syntax error if quirks mode is not enabled.