### PR TITLE
Output annotations with the namespace "annis" in find function.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Output annotations with the namespace "annis" in find function
 - Quirks mode: add additional identity joins in the order as the nodes are defined in the query
 
 ## [0.19.4] - 2019-05-10

--- a/src/annis/db/corpusstorage.rs
+++ b/src/annis/db/corpusstorage.rs
@@ -1091,7 +1091,7 @@ impl CorpusStorage {
                     let mut node_desc = String::new();
 
                     if let Some(anno_key) = db.node_annos.get_key_value(singlematch.anno_key) {
-                        if &anno_key.ns != "annis" {
+                        if &anno_key.ns != ANNIS_NS || &anno_key.name != NODE_TYPE {
                             if !anno_key.ns.is_empty() {
                                 node_desc.push_str(&anno_key.ns);
                                 node_desc.push_str("::");


### PR DESCRIPTION
Only queries for the actual node should be omitting the annotation part of the Salt ID.