### PR TITLE
Don't assume inverse operator has the same cost when fan-out is too different

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ This is especially important for `find`, where the implementation can be optimiz
 using the internal state.
 Such an optimization is impossible from outside when calling the API and not having access to the iterator.
 
+### Fixed
+
+- Don't assume inverse operator has the same cost when fan-out is too different. 
+Subgraph queries could be very slow for corpora with large documents due to an estimation error from this assumption 
+the `@` operator. 
+
 ## [0.24.0] - 2019-11-15
 
 ### Changed

--- a/src/annis/db/aql/operators/edge_op.rs
+++ b/src/annis/db/aql/operators/edge_op.rs
@@ -341,6 +341,12 @@ impl BinaryOperator for BaseEdgeOp {
             if !g.inverse_has_same_cost() {
                 return None;
             }
+            if let Some(stat) = g.get_statistics() {
+                // If input and output estimations are too different, also don't provide a more costly inverse operator
+                if stat.inverse_fan_out_99_percentile > stat.fan_out_99_percentile {
+                    return None;
+                }
+            }
         }
         let edge_op = BaseEdgeOp {
             gs: self.gs.clone(),


### PR DESCRIPTION
Subgraph queries could be very slow for corpora with large documents due to an estimation error from this assumption
the `@` operator.