### PR TITLE
Only use one XML parsing pass when importing GraphML.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Disk-based implementation of an adjacency list is used when a corpus is configured to be prefer disk over memory.
-- Ability to export and import GraphML files. This follows the [Neo4j dialect of GraphML](https://neo4j.com/docs/labs/apoc/current/import/graphml/)
+- Ability to export and import GraphML files. This follows the [Neo4j dialect of GraphML](https://neo4j.com/docs/labs/apoc/current/import/graphml/).
+  It is also possible to compress the GraphML files with Brotli.
 
 ### Fixed
 

--- a/cli/src/bin/annis.rs
+++ b/cli/src/bin/annis.rs
@@ -241,6 +241,8 @@ impl AnnisRunner {
                 let file_ext = file_ext.to_string_lossy().to_lowercase();
                 if file_ext == "graphml" || file_ext == "xml" {
                     format = ImportFormat::GraphML
+                } else if file_ext == "br" {
+                    format = ImportFormat::GraphMLCompressed
                 }
             }
         }
@@ -268,13 +270,19 @@ impl AnnisRunner {
         }
 
         let path = PathBuf::from(args[0]);
+        let mut format = ExportFormat::GraphML;
+        if let Some(file_ext) = path.extension() {
+            if file_ext.to_string_lossy() == "br" {
+                format = ExportFormat::GraphMLCompressed;
+            }
+        }
         let corpus = &self.current_corpus[0];
 
         let t_before = std::time::SystemTime::now();
         self.storage
             .as_ref()
             .ok_or(anyhow!("No corpus storage location set"))?
-            .export_to_fs(corpus, &path, ExportFormat::GraphML)?;
+            .export_to_fs(corpus, &path, format)?;
         let load_time = t_before.elapsed();
         if let Ok(t) = load_time {
             info! {"exported corpus {} in {} ms", corpus, (t.as_secs() * 1000 + t.subsec_nanos() as u64 / 1_000_000)};

--- a/core/src/graph/serialization/graphml.rs
+++ b/core/src/graph/serialization/graphml.rs
@@ -537,20 +537,22 @@ where
     let keys = read_keys(&mut input)?;
 
     let mut g = Graph::new(disk_based)?;
-    let mut updates = GraphUpdate::default();
+    let mut node_updates = GraphUpdate::default();
+    let mut edge_updates = GraphUpdate::default();
 
     // 2. pass: read in all nodes
     input.seek(SeekFrom::Start(0))?;
     progress_callback("reading all nodes");
-    read_nodes(&mut input, &mut updates, &keys)?;
+    read_nodes(&mut input, &mut node_updates, &keys)?;
 
     // 3. pass: read in all edges
     input.seek(SeekFrom::Start(0))?;
     progress_callback("reading all edges");
-    read_edges::<CT, BufReader<R>>(&mut input, &mut updates, &keys)?;
+    read_edges::<CT, BufReader<R>>(&mut input, &mut edge_updates, &keys)?;
 
-    // Apply all updates
-    g.apply_update(&mut updates, progress_callback)?;
+    // Apply node updates first: edges would not be added if the nodes they are referring do not exist
+    g.apply_update(&mut node_updates, &progress_callback)?;
+    g.apply_update(&mut edge_updates, progress_callback)?;
 
     Ok(g)
 }

--- a/graphannis/Cargo.toml
+++ b/graphannis/Cargo.toml
@@ -43,6 +43,7 @@ graphannis-malloc_size_of = "1.0"
 graphannis-malloc_size_of_derive = "2.0"
 strum = "0.18"
 strum_macros = "0.18"
+brotli = "3.3"
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
While this is slightly less efficient, it allows to use and readable stream to be imported directly. Before, only the ones implementing `Seek` (like files) could be used. This enables adding a compressed version of the import/export format, where the GraphML files are compressed/decompressed using Brotli on the fly (already implemented in this PR).