### PR TITLE
Create tokens for non-tokenized whitespace when importing from relANNIS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 /gh-pages
 /pcc21.zip
 /ridges7.zip
+/graphannis-trace.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add non-tokenized primary text segments as special nodes with the node type "white-space-token" when importing relANNIS.
+  These are connected with edges in the Ordering/annis/relannis.text component to the other token and allow to re-construct the
+  original relANNIS primary text.
+
 ## [0.28.0] - 2020-07-02
 
 ### Addded

--- a/cli/src/bin/annis.rs
+++ b/cli/src/bin/annis.rs
@@ -236,40 +236,41 @@ impl AnnisRunner {
         // Determine most likely input format based on the extension of the file
         let path = PathBuf::from(args[0]);
 
-        if path.is_file() {
-            if let Some(file_ext) = path.extension() {
-                let file_ext = file_ext.to_string_lossy().to_lowercase();
+        if path.exists() {
+            let file_ext_owned = path
+                .extension()
+                .map(|file_ext| file_ext.to_string_lossy().to_lowercase());
+            let file_ext = file_ext_owned.as_deref();
 
-                if file_ext == "zip" {
-                    // Import  ZIP file with possible multiple corpora
-                    let t_before = std::time::SystemTime::now();
-                    let names = self
-                        .storage
-                        .as_ref()
-                        .ok_or(anyhow!("No corpus storage location set"))?
-                        .import_all_from_zip(&path, self.use_disk)?;
-                    let load_time = t_before.elapsed();
-                    if let Ok(t) = load_time {
-                        info! {"imported corpora {:?} in {} ms", names, (t.as_secs() * 1000 + t.subsec_nanos() as u64 / 1_000_000)};
-                    }
-                } else {
-                    // Import a single corpus
-                    let mut format = ImportFormat::RelANNIS;
+            if file_ext == Some("zip") {
+                // Import  ZIP file with possible multiple corpora
+                let t_before = std::time::SystemTime::now();
+                let names = self
+                    .storage
+                    .as_ref()
+                    .ok_or(anyhow!("No corpus storage location set"))?
+                    .import_all_from_zip(&path, self.use_disk)?;
+                let load_time = t_before.elapsed();
+                if let Ok(t) = load_time {
+                    info! {"imported corpora {:?} in {} ms", names, (t.as_secs() * 1000 + t.subsec_nanos() as u64 / 1_000_000)};
+                }
+            } else {
+                // Import a single corpus
+                let mut format = ImportFormat::RelANNIS;
 
-                    if file_ext == "graphml" || file_ext == "xml" {
-                        format = ImportFormat::GraphML
-                    }
+                if file_ext == Some("graphml") || file_ext == Some("xml") {
+                    format = ImportFormat::GraphML
+                }
 
-                    let t_before = std::time::SystemTime::now();
-                    let name: String = self
-                        .storage
-                        .as_ref()
-                        .ok_or(anyhow!("No corpus storage location set"))?
-                        .import_from_fs(&path, format, overwritten_corpus_name, self.use_disk)?;
-                    let load_time = t_before.elapsed();
-                    if let Ok(t) = load_time {
-                        info! {"imported corpus {} in {} ms", name, (t.as_secs() * 1000 + t.subsec_nanos() as u64 / 1_000_000)};
-                    }
+                let t_before = std::time::SystemTime::now();
+                let name: String = self
+                    .storage
+                    .as_ref()
+                    .ok_or(anyhow!("No corpus storage location set"))?
+                    .import_from_fs(&path, format, overwritten_corpus_name, self.use_disk)?;
+                let load_time = t_before.elapsed();
+                if let Ok(t) = load_time {
+                    info! {"imported corpus {} in {} ms", name, (t.as_secs() * 1000 + t.subsec_nanos() as u64 / 1_000_000)};
                 }
             }
         }

--- a/graphannis/src/annis/db/relannis.rs
+++ b/graphannis/src/annis/db/relannis.rs
@@ -1102,7 +1102,7 @@ where
                         };
 
                         let created_token_id = format!(
-                            "artificial_white_space_token_{}_{}_{}_{}",
+                            "white_space_token_{}_{}_{}_{}",
                             t.name, current_text_offset, token_left_char, added_token_count,
                         );
 
@@ -1126,7 +1126,7 @@ where
                         // Add events
                         updates.add_event(UpdateEvent::AddNode {
                             node_name: created_token_id.clone(),
-                            node_type: "node".to_string(),
+                            node_type: "white_space_token".to_string(),
                         })?;
                         updates.add_event(UpdateEvent::AddNodeLabel {
                             node_name: created_token_id.clone(),

--- a/graphannis/src/annis/db/relannis.rs
+++ b/graphannis/src/annis/db/relannis.rs
@@ -1102,8 +1102,8 @@ where
                         };
 
                         let created_token_id = format!(
-                            "artificial_white_space_token_{}_{}_{}",
-                            t.name, current_text_offset, token_left_char
+                            "artificial_white_space_token_{}_{}_{}_{}",
+                            t.name, current_text_offset, token_left_char, added_token_count,
                         );
 
                         // Get the covered text
@@ -1145,7 +1145,7 @@ where
                                     id_to_node_name.try_get(&previous_token)?
                                 {
                                     updates.add_event(UpdateEvent::AddEdge {
-                                        source_node: previous_token,
+                                        source_node: previous_token.clone(),
                                         target_node: created_token_id.to_string(),
                                         component_type: "Ordering".to_string(),
                                         component_name: "text".to_string(),

--- a/graphannis/src/annis/db/relannis.rs
+++ b/graphannis/src/annis/db/relannis.rs
@@ -1147,7 +1147,8 @@ where
                                     updates.add_event(UpdateEvent::AddEdge {
                                         source_node: previous_token.clone(),
                                         target_node: created_token_id.to_string(),
-                                        component_type: "Ordering".to_string(),
+                                        component_type: AnnotationComponentType::Ordering
+                                            .to_string(),
                                         component_name: "relannis.text".to_string(),
                                         layer: ANNIS_NS.to_string(),
                                     })?;
@@ -1158,7 +1159,7 @@ where
                             updates.add_event(UpdateEvent::AddEdge {
                                 source_node: created_token_id.to_string(),
                                 target_node: next_token.to_string(),
-                                component_type: "Ordering".to_string(),
+                                component_type: AnnotationComponentType::Ordering.to_string(),
                                 component_name: "relannis.text".to_string(),
                                 layer: ANNIS_NS.to_string(),
                             })?;

--- a/graphannis/src/annis/db/relannis.rs
+++ b/graphannis/src/annis/db/relannis.rs
@@ -1487,7 +1487,7 @@ where
     let pos_parent = if is_annis_33 { 5 } else { 4 };
 
     // first run: collect all pre-order values for a node
-    let mut pre_to_node_id: BTreeMap<u32, NodeID> = BTreeMap::new();
+    let mut pre_to_node_id: DiskMap<u32, NodeID> = DiskMap::default();
     for result in rank_tab_csv.records() {
         let line = result?;
         let pre: u32 = line.get(0).ok_or(anyhow!("Missing column"))?.parse()?;
@@ -1495,7 +1495,7 @@ where
             .get(pos_node_ref)
             .ok_or(anyhow!("Missing column"))?
             .parse()?;
-        pre_to_node_id.insert(pre, node_id);
+        pre_to_node_id.insert(pre, node_id)?;
     }
 
     // second run: get the actual edges
@@ -1544,10 +1544,7 @@ where
 
                     let pre: u32 = line.get(0).ok_or(anyhow!("Missing column"))?.parse()?;
 
-                    let e = Edge {
-                        source: *source,
-                        target,
-                    };
+                    let e = Edge { source, target };
 
                     if c.get_type() == AnnotationComponentType::Coverage {
                         load_rank_result

--- a/graphannis/src/annis/db/relannis.rs
+++ b/graphannis/src/annis/db/relannis.rs
@@ -1148,7 +1148,7 @@ where
                                         source_node: previous_token.clone(),
                                         target_node: created_token_id.to_string(),
                                         component_type: "Ordering".to_string(),
-                                        component_name: "text".to_string(),
+                                        component_name: "relannis.text".to_string(),
                                         layer: ANNIS_NS.to_string(),
                                     })?;
                                 }
@@ -1159,7 +1159,7 @@ where
                                 source_node: created_token_id.to_string(),
                                 target_node: next_token.to_string(),
                                 component_type: "Ordering".to_string(),
-                                component_name: "text".to_string(),
+                                component_name: "relannis.text".to_string(),
                                 layer: ANNIS_NS.to_string(),
                             })?;
                         }

--- a/graphannis/src/annis/db/relannis.rs
+++ b/graphannis/src/annis/db/relannis.rs
@@ -180,6 +180,7 @@ impl KeySerializer for NodeByTextEntry {
 #[derive(Serialize, Deserialize, Clone, MallocSizeOf)]
 struct Text {
     name: String,
+    val: String,
 }
 
 struct CorpusTableEntry {
@@ -779,6 +780,9 @@ where
         let name = get_field_str(&line, if is_annis_33 { 2 } else { 1 })
             .ok_or(anyhow!("Missing column"))?;
 
+        let value = get_field_str(&line, if is_annis_33 { 3 } else { 2 })
+            .ok_or(anyhow!("Missing column"))?;
+
         let corpus_ref = if is_annis_33 {
             Some(
                 line.get(0)
@@ -789,7 +793,7 @@ where
             None
         };
         let key = TextKey { id, corpus_ref };
-        texts.insert(key.clone(), Text { name })?;
+        texts.insert(key.clone(), Text { name, val: value })?;
     }
 
     Ok(texts)
@@ -1035,6 +1039,88 @@ where
                 )
             }
         } // end if not a token
+    }
+
+    Ok(())
+}
+
+fn add_white_space_token<F>(
+    updates: &mut GraphUpdate,
+    textpos_table: &TextPosTable,
+    texts: &mut DiskMap<TextKey, Text>,
+    id_to_node_name: &DiskMap<NodeID, String>,
+    progress_callback: &F,
+) -> Result<()>
+where
+    F: Fn(&str) -> (),
+{
+    progress_callback("Adding non-tokenized primary text segments as white-space tokens.");
+    // Go through each discovered token and check if there is whitespace before this token in the original text.
+    let mut white_space_range_start = 0;
+    for (token_text_pos, next_real_token_id) in textpos_table.token_by_index.iter() {
+        // Get the left character border for this token
+        if let (Some(left_text_pos), Some(right_text_pos)) = (
+            textpos_table.node_to_left.try_get(&next_real_token_id)?,
+            textpos_table.node_to_right.try_get(&next_real_token_id)?,
+        ) {
+            let left_char = left_text_pos.val;
+            if white_space_range_start < left_char {
+                // Create the new white space token from the start to left border of this token
+                let text_key = TextKey {
+                    corpus_ref: Some(token_text_pos.corpus_id),
+                    id: token_text_pos.text_id,
+                };
+                if let Some(t) = texts.try_get(&text_key)? {
+                    let covered_text =
+                        &t.val[(white_space_range_start as usize)..(left_char as usize)];
+                    let created_token_id = format!(
+                        "artificial_white_space_token_{}_{}_{}",
+                        t.name, white_space_range_start, left_char
+                    );
+                    updates.add_event(UpdateEvent::AddNode {
+                        node_name: created_token_id.clone(),
+                        node_type: "node".to_string(),
+                    })?;
+                    updates.add_event(UpdateEvent::AddNodeLabel {
+                        node_name: created_token_id.clone(),
+                        anno_ns: ANNIS_NS.to_string(),
+                        anno_name: TOK.to_string(),
+                        anno_value: covered_text.to_string(),
+                    })?;
+                    // Connect the new node with Ordering edges to the token before and after
+                    let previous_token_text_prop = TextProperty {
+                        segmentation: left_text_pos.segmentation.to_string(),
+                        corpus_id: left_text_pos.corpus_id,
+                        text_id: left_text_pos.text_id,
+                        val: white_space_range_start - 1,
+                    };
+                    if let Some(previous_token) = textpos_table
+                        .token_by_right_textpos
+                        .try_get(&previous_token_text_prop)?
+                    {
+                        if let Some(previous_token) = id_to_node_name.try_get(&previous_token)? {
+                            updates.add_event(UpdateEvent::AddEdge {
+                                source_node: previous_token,
+                                target_node: created_token_id.to_string(),
+                                component_type: "Ordering".to_string(),
+                                component_name: "text".to_string(),
+                                layer: ANNIS_NS.to_string(),
+                            })?;
+                        }
+                    }
+                    if let Some(next_token) = id_to_node_name.try_get(&next_real_token_id)? {
+                        updates.add_event(UpdateEvent::AddEdge {
+                            source_node: created_token_id.to_string(),
+                            target_node: next_token.to_string(),
+                            component_type: "Ordering".to_string(),
+                            component_name: "text".to_string(),
+                            layer: ANNIS_NS.to_string(),
+                        })?;
+                    }
+                    white_space_range_start = right_text_pos.val;
+                }
+            }
+        }
     }
 
     Ok(())
@@ -1440,6 +1526,14 @@ where
         &node_tab_parse_result.missing_seg_span,
         &node_tab_parse_result.id_to_node_name,
         is_annis_33,
+        progress_callback,
+    )?;
+
+    add_white_space_token(
+        updates,
+        &node_tab_parse_result.textpos_table,
+        texts,
+        &node_tab_parse_result.id_to_node_name,
         progress_callback,
     )?;
 


### PR DESCRIPTION
Since the text of the primary data sources is not stored as a label (because this would be huge for some texts), we need another way to reconstruct the original primary text for documents imported from relANNIS. By adding the white space segments as tokens (but with the special node type "white-space-token") and connected them with ordering edges this becomes possible.