### PR TITLE
Use special token labels to encode the whitespace text between tokens…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add non-tokenized primary text segments as special nodes with the node type "white-space-token" when importing relANNIS.
-  These are connected with edges in the Ordering/annis/relannis.text component to the other token and allow to re-construct the
-  original relANNIS primary text.
+- Add non-tokenized primary text segments as special labels "tok-whitespace-before" and "tok-whitespace-after" to the existing token
+  when importing from relANNIS. This allows to re-construct the original relANNIS primary text by iterating over all token in order 
+  and be prepending or append these labels to the token values.
 
 ### Fixed
 

--- a/cli/src/bin/annis.rs
+++ b/cli/src/bin/annis.rs
@@ -567,7 +567,15 @@ impl AnnisRunner {
             for row in frequency_table.into_iter() {
                 let mut out_row = Row::empty();
                 for att in row.0.iter() {
-                    out_row.add_cell(Cell::from(att));
+                    if att.trim().is_empty() {
+                        // This is whitespace only, add some quotation marks to show to make it visible
+                        let mut val = "'".to_owned();
+                        val.push_str(att);
+                        val.push('\'');
+                        out_row.add_cell(Cell::from(&val));
+                    } else {
+                        out_row.add_cell(Cell::from(att));
+                    }
                 }
                 // also add the count
                 out_row.add_cell(Cell::from(&row.1));

--- a/graphannis/src/annis/db/aql/model.rs
+++ b/graphannis/src/annis/db/aql/model.rs
@@ -24,7 +24,8 @@ use crate::{
 };
 
 pub const TOK: &str = "tok";
-pub const IGNORED_TOK: &str = "ignored-tok";
+pub const TOK_WHITESPACE_BEFORE: &str = "tok-whitespace-before";
+pub const TOK_WHITESPACE_AFTER: &str = "tok-whitespace-after";
 
 lazy_static! {
     pub static ref TOKEN_KEY: Arc<AnnoKey> = Arc::from(AnnoKey {


### PR DESCRIPTION
… when importing from relANNIS.

This replaces the approach of #151 