### PR TITLE
Decode corpus names before listing them.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adding `\$` to the escaped input sequence in the relANNIS import, fixing issues with some old SFB 632 corpora
 - Unbound near-by-operator (`^*`) was not limited to 50 in quirks mode
 - Workaround for duplicated document names when importing invalid relANNIS corpora
+- Corpus names with non-ASCII characters where not listed with their decoded name
 
 ## Changed
 

--- a/graphannis/src/annis/db/corpusstorage.rs
+++ b/graphannis/src/annis/db/corpusstorage.rs
@@ -32,7 +32,7 @@ use graphannis_core::{
     util::memory_estimation,
 };
 use linked_hash_map::LinkedHashMap;
-use percent_encoding::{utf8_percent_encode, AsciiSet, CONTROLS};
+use percent_encoding::{percent_decode_str, utf8_percent_encode, AsciiSet, CONTROLS};
 use std::borrow::Cow;
 use std::collections::{BTreeSet, HashSet};
 use std::fmt;
@@ -518,8 +518,11 @@ impl CorpusStorage {
                 )
             })?;
             if ftype.is_dir() {
-                let corpus_name = c_dir.file_name().to_string_lossy().to_string();
-                corpora.push(corpus_name.clone());
+                let directory_name = c_dir.file_name();
+                let corpus_name = directory_name.to_string_lossy();
+                // Use the decoded corpus name instead of the directory name
+                let corpus_name = percent_decode_str(&corpus_name);
+                corpora.push(corpus_name.decode_utf8_lossy().to_string());
             }
         }
         Ok(corpora)


### PR DESCRIPTION
We already make sure corpus names with non-ASCII characters are supported by encoding their directory name. When listing them we need to decode them, otherwise e.g. the REST API won't allow any search form them because their existince ist first checked.