### PR TITLE
Add the possibility to change the amount of RAM used for the corpus cache in the web service.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Changed
 
+- The `FixedMaxMemory` `CacheStrategy` now uses Megabytes instead of bytes.
 - There can be multiple `--cmd` arguments for the CLI, which are executed in the order they are given.
+
+## Added
+
+- The webservice configuration now allows to configure the size of the in-memory corpus cache.
 
 ## [0.30.0] - 2020-09-30
 

--- a/docs/src/rest/configuration.md
+++ b/docs/src/rest/configuration.md
@@ -51,7 +51,10 @@ cache = {FixedMaxMemory = 8000}
 at most 8 GB of RAM.
 
 ## [logging] section
-toml
+
+Per default, graphANNIS will only output information, warning and error messages.
+To also enable debug output, set the value for the `debug` field to `true`.
+
 ## [auth] section
 
 This section configures the [authentication and authorization](auth.md) of the REST service.

--- a/docs/src/rest/configuration.md
+++ b/docs/src/rest/configuration.md
@@ -13,6 +13,7 @@ host = "localhost"
 graphannis = "data/"
 sqlite = "service.sqlite"
 disk_based = false
+cache = {PercentOfFreeMemory = 25.0}
 
 [logging]
 debug = false
@@ -33,11 +34,24 @@ For configuration unique to the REST service, a small SQLite database is used, w
 A new database file will be created at this path when the service is started and the file does not exist yet.
 Also, you can decide if you want to prefer disk-based storage of annotations by setting the value for the `disk_based` key to `true`.
 
+You can configure how much memory is used by the service for caching loaded corpora with the `cache` key.
+There are two types of strategies: 
+
+- `PercentOfFreeMemory` estimates the free space of memory for the system during startup and only uses the given value (as percent) of the available free space. 
+- `FixedMaxMemory` will use at most the given value in Megabytes.
+
+For example, setting the configuration value to
+```toml
+cache = {PercentOfFreeMemory = 80.0}
+``` 
+will use 80% of the available free memory and 
+```toml
+cache = {FixedMaxMemory = 8000}
+``` 
+at most 8 GB of RAM.
+
 ## [logging] section
-
-Per default, graphANNIS will only output information, warning and error messages.
-To also enable debug output, set the value for the `debug` field to `true`.
-
+toml
 ## [auth] section
 
 This section configures the [authentication and authorization](auth.md) of the REST service.

--- a/webservice/src/main.rs
+++ b/webservice/src/main.rs
@@ -85,7 +85,11 @@ fn init_app() -> anyhow::Result<(graphannis::CorpusStorage, settings::Settings, 
 
     // Create a graphANNIS corpus storage as shared state
     let data_dir = std::path::PathBuf::from(&settings.database.graphannis);
-    let cs = graphannis::CorpusStorage::with_auto_cache_size(&data_dir, true)?;
+    let cs = graphannis::CorpusStorage::with_cache_strategy(
+        &data_dir,
+        settings.database.cache.clone(),
+        true,
+    )?;
 
     // Add a connection pool to the SQLite database
 
@@ -97,10 +101,11 @@ fn init_app() -> anyhow::Result<(graphannis::CorpusStorage, settings::Settings, 
     embedded_migrations::run(&conn)?;
 
     info!(
-        "Using database {}",
+        "Using database {} with at most {} of RAM for the corpus cache.",
         PathBuf::from(&settings.database.sqlite)
             .canonicalize()?
-            .to_string_lossy()
+            .to_string_lossy(),
+        &settings.database.cache
     );
 
     Ok((cs, settings, db_pool))

--- a/webservice/src/settings.rs
+++ b/webservice/src/settings.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use config::ConfigError;
+use graphannis::corpusstorage::CacheStrategy;
 use jsonwebtoken::DecodingKey;
 use std::ops::Deref;
 
@@ -19,6 +20,8 @@ pub struct Database {
     pub graphannis: String,
     pub sqlite: String,
     pub disk_based: bool,
+    #[serde(default)]
+    pub cache: CacheStrategy,
 }
 
 #[derive(Debug, Deserialize)]


### PR DESCRIPTION
This also changes the `FixedMaxMemory` variant of the `CacheStrategy` enum to use Megaybtes instead of bytes.