### PR TITLE
Ignore missing files directory when getting the linked files.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,7 +67,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-integration-tests-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-integration-tests-${{ hashFiles('**/Cargo.toml', '**/Cargo.lock') }}
       - run: cargo update
       - name: Build CLI binary
         run: cargo build --release --bin annis

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml', '**/Cargo.lock') }}
       - run: cargo update
       - run: cargo build --all-features --verbose
       - run: cargo test --all-features --verbose
@@ -38,7 +38,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml', '**/Cargo.lock') }}
       - run: cargo update
       - run: cargo build --all-features --verbose
       - run: cargo test --all-features --verbose
@@ -50,6 +50,13 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml', '**/Cargo.lock') }}
       - run: cargo update
       - run: cargo build --all-features --verbose
       - run: cargo test --all-features --verbose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Renamed (public) function `export_corpus_zip` in `CorpusStorage` to `export_to_zip` to align with the other export function name.
 
+### Fixed
+
+- Exporting a corpus without a "files" directory failed
 
 ## [0.31.2] - 2021-04-01
 


### PR DESCRIPTION
We canonicalize the path to the files directory, but this assumes it exists.
An error was thrown when it did not, which is changed to an optional value in this PR.