### PR TITLE
Add 0 to default available context sizes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- The default context sizes in the corpus configuration now include 0 (#181)
+
 ## [0.32.0] - 2021-08-09
 
 ### Added

--- a/graphannis/src/annis/types.rs
+++ b/graphannis/src/annis/types.rs
@@ -103,7 +103,7 @@ impl Default for ContextConfiguration {
             default: 5,
             segmentation: None,
             max: None,
-            sizes: vec![1, 2, 5, 10],
+            sizes: vec![0, 1, 2, 5, 10],
         }
     }
 }


### PR DESCRIPTION
This fixes #181 for corpora imported from relANNIS.