### PR TITLE
Don't allow optional operands for non-negated operators

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Don't allow optional operands for non-negated operators
+
 ## [1.2.0] - 2021-09-16
 
 ### Added

--- a/graphannis/src/annis/db/aql/mod.rs
+++ b/graphannis/src/annis/db/aql/mod.rs
@@ -181,7 +181,22 @@ fn map_conjunction(
                     q.add_unary_operator_from_query(Arc::new(spec), &filtered_var, op_pos)?;
                 }
             } else {
-                q.add_operator_from_query(op_spec, &var_left, &var_right, op_pos, !quirks_mode)?;
+                if node_left.optional || node_right.optional {
+                    // Not supported yet
+                    return Err(GraphAnnisError::AQLSemanticError(AQLError {
+                        desc: format!(
+                            "Optional left or right operands can only be combined with a negated operator."),
+                        location: op_pos,
+                    }));
+                } else {
+                    q.add_operator_from_query(
+                        op_spec,
+                        &var_left,
+                        &var_right,
+                        op_pos,
+                        !quirks_mode,
+                    )?;
+                }
             }
         }
     }


### PR DESCRIPTION
This might be supported in the future to allow e.g. for nodes to be not included in the result output, but the current behavior is neither tested or well-defined so disallow this scenario for now.