### PR TITLE
Limit memory consumption during relANNIS import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Reduce memory footprint during import when corpus contains a lot of escaped strings (as in #205)
 - Limit the used main memory cache per `DiskTable` to about 100MB in the default configuration.
   Since we use a lot of disk-based maps during import of relANNIS files, this can add up to > 1GB easily.
   The maximum cache usage was much larger before, which amongst other issues caused #205 to happen.
   With this change, during relANNIS import the main memory usage should be limited to be less than 4GB, 
   which seams more reasonable than the previous 20+GB
+- Reduce memory footprint during import when corpus contains a lot of escaped strings (as in #205)
+- Avoid creating small fragmented main memory when importing corpora from relANNIS to help to fix #205
 
 ## [1.3.0] - 2021-09-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Reduce memory footprint during import when corpus contains a lot of escaped strings (as in #205)
+
 ## [1.3.0] - 2021-09-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Reduce memory footprint during import when corpus contains a lot of escaped strings (as in #205)
+- Limit the used main memory cache per `DiskTable` to about 100MB in the default configuration.
+  Since we use a lot of disk-based maps during import of relANNIS files, this can add up to > 1GB easily.
+  The maximum cache usage was much larger before, which amongst other issues caused #205 to happen.
+  With this change, during relANNIS import the main memory usage should be limited to be less than 4GB, 
+  which seams more reasonable than the previous 20+GB
 
 ## [1.3.0] - 2021-09-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Limit the used main memory cache per `DiskTable` to about 100MB in the default configuration.
-  Since we use a lot of disk-based maps during import of relANNIS files, this can add up to > 1GB easily.
-  The maximum cache usage was much larger before, which amongst other issues caused #205 to happen.
+- Limit the used main memory cache per `DiskTable` by only using a disk block cache for the C1 table.
+  Since we use a lot of disk-based maps during import of relANNIS files, the previous behavior could 
+  add up to > 1GB easily, wich amongst other issues caused #205 to happen.
   With this change, during relANNIS import the main memory usage should be limited to be less than 4GB, 
   which seams more reasonable than the previous 20+GB
 - Reduce memory footprint during import when corpus contains a lot of escaped strings (as in #205)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,9 @@
 [workspace]
 members = [
-    "core",
-    "graphannis",
-    "cli",
-    "capi",
-    "webservice",
-    "examples/tutorial"
+  "core",
+  "graphannis",
+  "cli",
+  "capi",
+  "webservice",
+  "examples/tutorial",
 ]
-
-[patch.crates-io]
-sstable = { path = "../sstable" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,12 @@
 [workspace]
-members = ["core", "graphannis", "cli", "capi", "webservice", "examples/tutorial"]
+members = [
+    "core",
+    "graphannis",
+    "cli",
+    "capi",
+    "webservice",
+    "examples/tutorial"
+]
+
+[patch.crates-io]
+sstable = { path = "../sstable" }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -11,15 +11,16 @@ version = "1.3.0"
 
 [dependencies]
 anyhow = "1"
-clap = {version = "2", default-features = false}
+clap = { version = "2", default-features = false }
 criterion = "0.3"
-graphannis = {path = "../graphannis/", version = "^1.0"}
+graphannis = { path = "../graphannis/", version = "^1.0" }
 log = "0.4"
 prettytable-rs = "0.8"
 rustyline = "9"
 rustyline-derive = "0.5"
 simplelog = "0.10"
 toml = "0.5"
+compound_duration = "1"
 
 [[bin]]
 name = "annis"

--- a/cli/src/bin/annis.rs
+++ b/cli/src/bin/annis.rs
@@ -2,6 +2,7 @@
 extern crate anyhow;
 
 use clap::{App, Arg};
+use compound_duration::format_dhms;
 use graphannis::corpusstorage::FrequencyDefEntry;
 use graphannis::corpusstorage::LoadStatus;
 use graphannis::corpusstorage::QueryLanguage;
@@ -259,7 +260,11 @@ impl AnnisRunner {
                     })?;
                 let load_time = t_before.elapsed();
                 if let Ok(t) = load_time {
-                    info! {"imported corpora {:?} in {} ms", names, (t.as_secs() * 1000 + t.subsec_nanos() as u64 / 1_000_000)};
+                    info!(
+                        "imported corpora {:?} in {}",
+                        names,
+                        format_dhms(t.as_secs())
+                    );
                 }
             } else {
                 // Import a single corpus
@@ -284,7 +289,7 @@ impl AnnisRunner {
                     )?;
                 let load_time = t_before.elapsed();
                 if let Ok(t) = load_time {
-                    info! {"imported corpus {} in {} ms", name, (t.as_secs() * 1000 + t.subsec_nanos() as u64 / 1_000_000)};
+                    info!("imported corpus {} in {}", name, format_dhms(t.as_secs()));
                 }
             }
         }
@@ -320,7 +325,11 @@ impl AnnisRunner {
             .export_to_fs(&self.current_corpus, &path, format)?;
         let load_time = t_before.elapsed();
         if let Ok(t) = load_time {
-            info! {"exported corpora {:?} in {} ms", &self.current_corpus, (t.as_secs() * 1000 + t.subsec_nanos() as u64 / 1_000_000)};
+            info!(
+                "exported corpora {:?} in {}",
+                &self.current_corpus,
+                format_dhms(t.as_secs())
+            );
         }
 
         Ok(())

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -30,7 +30,7 @@ serde = {version = "1.0", features = ["rc"]}
 serde_derive = "1.0"
 smallvec = "1.6"
 smartstring = {version = "0.2", features = ["serde"]}
-sstable = "0.8.2"
+sstable = "0.9"
 strum = "0.21"
 strum_macros = "0.21"
 tempfile = "3.1"

--- a/core/src/annostorage/mod.rs
+++ b/core/src/annostorage/mod.rs
@@ -248,9 +248,9 @@ where
     /// This can be used to calculate new IDs for new items.
     fn get_largest_item(&self) -> Option<T>;
 
-    /// (Re-) calculate the internal statistics needed for estimitating annotation values.
+    /// (Re-) calculate the internal statistics needed for estimating annotation values.
     ///
-    /// An annotation storage can not have a valid statistics, in which case the estimitation function will not return
+    /// An annotation storage can invalid statistics, in which case the estimation function will not return
     /// valid results.
     fn calculate_statistics(&mut self);
 

--- a/core/src/annostorage/ondisk.rs
+++ b/core/src/annostorage/ondisk.rs
@@ -311,20 +311,12 @@ where
         self.by_container
             .insert(by_container_key, anno.val.clone().into())?;
 
-        if self.by_container.number_of_disk_tables() > 7 {
-            self.by_container.compact()?;
-        }
-
         // To save some space, insert an empty array as a marker value
         // (all information is part of the key already)
         self.by_anno_qname.insert(
             create_by_anno_qname_key(item.clone(), anno_key_symbol, &anno.val),
             true,
         )?;
-
-        if self.by_anno_qname.number_of_disk_tables() > 7 {
-            self.by_anno_qname.compact()?;
-        }
 
         if !already_existed {
             // a new annotation entry was inserted and did not replace an existing one

--- a/core/src/annostorage/ondisk.rs
+++ b/core/src/annostorage/ondisk.rs
@@ -72,8 +72,8 @@ where
 /// [x Bits item ID][64 Bits symbol ID]
 /// ```
 fn create_by_container_key<T: FixedSizeKeySerializer>(item: T, anno_key_symbol: usize) -> Vec<u8> {
-    let mut result: Vec<u8> = Vec::from(item.create_key());
-    result.extend_from_slice(&anno_key_symbol.create_key());
+    let mut result: Vec<u8> = item.create_key().to_vec();
+    result.extend(anno_key_symbol.create_key());
     result
 }
 
@@ -92,7 +92,7 @@ fn create_by_anno_qname_key<T: FixedSizeKeySerializer>(
     anno_value: &str,
 ) -> Vec<u8> {
     // Use the qualified annotation name, the value and the node ID as key for the indexes.
-    let mut result: Vec<u8> = Vec::from(anno_key_symbol.create_key());
+    let mut result: Vec<u8> = anno_key_symbol.create_key().to_vec();
     for b in anno_value.as_bytes() {
         result.push(*b);
     }

--- a/core/src/graph/mod.rs
+++ b/core/src/graph/mod.rs
@@ -554,6 +554,9 @@ impl<CT: ComponentType> Graph<CT> {
             }
         } // end for each consistent update entry
 
+        progress_callback("calculating node statistics");
+        self.get_node_annos_mut().calculate_statistics();
+
         progress_callback("extending graph with model-specific index");
         ComponentType::apply_update_graph_index(update_graph_index, self)?;
 

--- a/core/src/serializer.rs
+++ b/core/src/serializer.rs
@@ -1,6 +1,6 @@
 use std::convert::TryInto;
 
-pub type KeyVec = smallvec::SmallVec<[u8; 8]>;
+pub type KeyVec = smallvec::SmallVec<[u8; 32]>;
 
 pub trait KeySerializer {
     fn create_key(&self) -> KeyVec;

--- a/core/src/serializer.rs
+++ b/core/src/serializer.rs
@@ -37,7 +37,7 @@ impl KeySerializer for String {
 
 impl KeySerializer for u8 {
     fn create_key(&self) -> Cow<[u8]> {
-        Cow::Owned(self.to_be_bytes().to_vec())
+        Cow::Owned(self.to_be_bytes().into())
     }
 
     fn parse_key(key: &[u8]) -> Self {
@@ -57,7 +57,7 @@ impl FixedSizeKeySerializer for u8 {
 
 impl KeySerializer for u16 {
     fn create_key(&self) -> Cow<[u8]> {
-        Cow::Owned(self.to_be_bytes().to_vec())
+        Cow::Owned(self.to_be_bytes().into())
     }
 
     fn parse_key(key: &[u8]) -> Self {
@@ -77,7 +77,7 @@ impl FixedSizeKeySerializer for u16 {
 
 impl KeySerializer for u32 {
     fn create_key(&self) -> Cow<[u8]> {
-        Cow::Owned(self.to_be_bytes().to_vec())
+        Cow::Owned(self.to_be_bytes().into())
     }
 
     fn parse_key(key: &[u8]) -> Self {
@@ -97,7 +97,7 @@ impl FixedSizeKeySerializer for u32 {
 
 impl KeySerializer for u64 {
     fn create_key(&self) -> Cow<[u8]> {
-        Cow::Owned(self.to_be_bytes().to_vec())
+        Cow::Owned(self.to_be_bytes().into())
     }
 
     fn parse_key(key: &[u8]) -> Self {
@@ -117,7 +117,7 @@ impl FixedSizeKeySerializer for u64 {
 
 impl KeySerializer for u128 {
     fn create_key(&self) -> Cow<[u8]> {
-        Cow::Owned(self.to_be_bytes().to_vec())
+        Cow::Owned(self.to_be_bytes().into())
     }
 
     fn parse_key(key: &[u8]) -> Self {
@@ -137,7 +137,7 @@ impl FixedSizeKeySerializer for u128 {
 
 impl KeySerializer for usize {
     fn create_key(&self) -> Cow<[u8]> {
-        Cow::Owned(self.to_be_bytes().to_vec())
+        Cow::Owned(self.to_be_bytes().into())
     }
 
     fn parse_key(key: &[u8]) -> Self {
@@ -151,7 +151,7 @@ impl KeySerializer for usize {
 
 impl KeySerializer for i8 {
     fn create_key(&self) -> Cow<[u8]> {
-        Cow::Owned(self.to_be_bytes().to_vec())
+        Cow::Owned(self.to_be_bytes().into())
     }
 
     fn parse_key(key: &[u8]) -> Self {
@@ -171,7 +171,7 @@ impl FixedSizeKeySerializer for i8 {
 
 impl KeySerializer for i16 {
     fn create_key(&self) -> Cow<[u8]> {
-        Cow::Owned(self.to_be_bytes().to_vec())
+        Cow::Owned(self.to_be_bytes().into())
     }
 
     fn parse_key(key: &[u8]) -> Self {
@@ -191,7 +191,7 @@ impl FixedSizeKeySerializer for i16 {
 
 impl KeySerializer for i32 {
     fn create_key(&self) -> Cow<[u8]> {
-        Cow::Owned(self.to_be_bytes().to_vec())
+        Cow::Owned(self.to_be_bytes().into())
     }
 
     fn parse_key(key: &[u8]) -> Self {
@@ -211,7 +211,7 @@ impl FixedSizeKeySerializer for i32 {
 
 impl KeySerializer for i64 {
     fn create_key(&self) -> Cow<[u8]> {
-        Cow::Owned(self.to_be_bytes().to_vec())
+        Cow::Owned(self.to_be_bytes().into())
     }
 
     fn parse_key(key: &[u8]) -> Self {
@@ -231,7 +231,7 @@ impl FixedSizeKeySerializer for i64 {
 
 impl KeySerializer for i128 {
     fn create_key(&self) -> Cow<[u8]> {
-        Cow::Owned(self.to_be_bytes().to_vec())
+        Cow::Owned(self.to_be_bytes().into())
     }
 
     fn parse_key(key: &[u8]) -> Self {

--- a/core/src/serializer.rs
+++ b/core/src/serializer.rs
@@ -1,8 +1,9 @@
-use std::borrow::Cow;
 use std::convert::TryInto;
 
+pub type KeyVec = smallvec::SmallVec<[u8; 8]>;
+
 pub trait KeySerializer {
-    fn create_key(&self) -> Cow<[u8]>;
+    fn create_key(&self) -> KeyVec;
     fn parse_key(key: &[u8]) -> Self
     where
         Self: std::marker::Sized;
@@ -15,8 +16,8 @@ pub trait FixedSizeKeySerializer: KeySerializer {
 const PANIC_MESSAGE_SIZE: &str = "Key data must fullfill minimal size for type";
 
 impl KeySerializer for Vec<u8> {
-    fn create_key(&self) -> Cow<[u8]> {
-        Cow::Borrowed(self)
+    fn create_key(&self) -> KeyVec {
+        KeyVec::from_slice(self)
     }
 
     fn parse_key(key: &[u8]) -> Self {
@@ -24,9 +25,19 @@ impl KeySerializer for Vec<u8> {
     }
 }
 
+impl KeySerializer for KeyVec {
+    fn create_key(&self) -> KeyVec {
+        self.clone()
+    }
+
+    fn parse_key(key: &[u8]) -> Self {
+        KeyVec::from(key)
+    }
+}
+
 impl KeySerializer for String {
-    fn create_key(&self) -> Cow<[u8]> {
-        Cow::Borrowed(self.as_bytes())
+    fn create_key(&self) -> KeyVec {
+        KeyVec::from_slice(self.as_bytes())
     }
 
     fn parse_key(key: &[u8]) -> Self {
@@ -36,8 +47,8 @@ impl KeySerializer for String {
 }
 
 impl KeySerializer for u8 {
-    fn create_key(&self) -> Cow<[u8]> {
-        Cow::Owned(self.to_be_bytes().into())
+    fn create_key(&self) -> KeyVec {
+        KeyVec::from_slice(&self.to_be_bytes())
     }
 
     fn parse_key(key: &[u8]) -> Self {
@@ -56,8 +67,8 @@ impl FixedSizeKeySerializer for u8 {
 }
 
 impl KeySerializer for u16 {
-    fn create_key(&self) -> Cow<[u8]> {
-        Cow::Owned(self.to_be_bytes().into())
+    fn create_key(&self) -> KeyVec {
+        KeyVec::from_slice(&self.to_be_bytes())
     }
 
     fn parse_key(key: &[u8]) -> Self {
@@ -76,8 +87,8 @@ impl FixedSizeKeySerializer for u16 {
 }
 
 impl KeySerializer for u32 {
-    fn create_key(&self) -> Cow<[u8]> {
-        Cow::Owned(self.to_be_bytes().into())
+    fn create_key(&self) -> KeyVec {
+        KeyVec::from_slice(&self.to_be_bytes())
     }
 
     fn parse_key(key: &[u8]) -> Self {
@@ -96,8 +107,8 @@ impl FixedSizeKeySerializer for u32 {
 }
 
 impl KeySerializer for u64 {
-    fn create_key(&self) -> Cow<[u8]> {
-        Cow::Owned(self.to_be_bytes().into())
+    fn create_key(&self) -> KeyVec {
+        KeyVec::from_slice(&self.to_be_bytes())
     }
 
     fn parse_key(key: &[u8]) -> Self {
@@ -116,8 +127,8 @@ impl FixedSizeKeySerializer for u64 {
 }
 
 impl KeySerializer for u128 {
-    fn create_key(&self) -> Cow<[u8]> {
-        Cow::Owned(self.to_be_bytes().into())
+    fn create_key(&self) -> KeyVec {
+        KeyVec::from_slice(&self.to_be_bytes())
     }
 
     fn parse_key(key: &[u8]) -> Self {
@@ -136,8 +147,8 @@ impl FixedSizeKeySerializer for u128 {
 }
 
 impl KeySerializer for usize {
-    fn create_key(&self) -> Cow<[u8]> {
-        Cow::Owned(self.to_be_bytes().into())
+    fn create_key(&self) -> KeyVec {
+        KeyVec::from_slice(&self.to_be_bytes())
     }
 
     fn parse_key(key: &[u8]) -> Self {
@@ -150,8 +161,8 @@ impl KeySerializer for usize {
 }
 
 impl KeySerializer for i8 {
-    fn create_key(&self) -> Cow<[u8]> {
-        Cow::Owned(self.to_be_bytes().into())
+    fn create_key(&self) -> KeyVec {
+        KeyVec::from_slice(&self.to_be_bytes())
     }
 
     fn parse_key(key: &[u8]) -> Self {
@@ -170,8 +181,8 @@ impl FixedSizeKeySerializer for i8 {
 }
 
 impl KeySerializer for i16 {
-    fn create_key(&self) -> Cow<[u8]> {
-        Cow::Owned(self.to_be_bytes().into())
+    fn create_key(&self) -> KeyVec {
+        KeyVec::from_slice(&self.to_be_bytes())
     }
 
     fn parse_key(key: &[u8]) -> Self {
@@ -190,8 +201,8 @@ impl FixedSizeKeySerializer for i16 {
 }
 
 impl KeySerializer for i32 {
-    fn create_key(&self) -> Cow<[u8]> {
-        Cow::Owned(self.to_be_bytes().into())
+    fn create_key(&self) -> KeyVec {
+        KeyVec::from_slice(&self.to_be_bytes())
     }
 
     fn parse_key(key: &[u8]) -> Self {
@@ -210,8 +221,8 @@ impl FixedSizeKeySerializer for i32 {
 }
 
 impl KeySerializer for i64 {
-    fn create_key(&self) -> Cow<[u8]> {
-        Cow::Owned(self.to_be_bytes().into())
+    fn create_key(&self) -> KeyVec {
+        KeyVec::from_slice(&self.to_be_bytes())
     }
 
     fn parse_key(key: &[u8]) -> Self {
@@ -230,8 +241,8 @@ impl FixedSizeKeySerializer for i64 {
 }
 
 impl KeySerializer for i128 {
-    fn create_key(&self) -> Cow<[u8]> {
-        Cow::Owned(self.to_be_bytes().into())
+    fn create_key(&self) -> KeyVec {
+        KeyVec::from_slice(&self.to_be_bytes())
     }
 
     fn parse_key(key: &[u8]) -> Self {

--- a/core/src/types.rs
+++ b/core/src/types.rs
@@ -3,12 +3,12 @@ use smartstring::alias::String;
 use std::fmt;
 use std::ops::AddAssign;
 
-use std::borrow::Cow;
 use std::{convert::TryInto, str::FromStr};
 use strum::IntoEnumIterator;
 use strum_macros::{EnumIter, EnumString};
 
 use super::serializer::{FixedSizeKeySerializer, KeySerializer};
+use crate::serializer::KeyVec;
 use crate::{
     errors::{ComponentTypeError, GraphAnnisCoreError},
     graph::{update::UpdateEvent, Graph},
@@ -80,11 +80,11 @@ impl Edge {
 }
 
 impl KeySerializer for Edge {
-    fn create_key(&self) -> Cow<[u8]> {
-        let mut result = Vec::with_capacity(std::mem::size_of::<NodeID>() * 2);
-        result.extend(&self.source.to_be_bytes());
-        result.extend(&self.target.to_be_bytes());
-        Cow::Owned(result)
+    fn create_key(&self) -> KeyVec {
+        let mut result = KeyVec::new();
+        result.extend(self.source.to_be_bytes());
+        result.extend(self.target.to_be_bytes());
+        result
     }
 
     fn parse_key(key: &[u8]) -> Self {

--- a/core/src/util/disk_collections.rs
+++ b/core/src/util/disk_collections.rs
@@ -453,9 +453,11 @@ where
     pub fn compact(&mut self) -> Result<()> {
         self.est_sum_memory = 0;
 
-        if self.c0.is_empty() && self.disk_tables.is_empty() {
-            // The table is completly empty, there is nothing to do
-            return Ok(());
+        if self.c0.is_empty() {
+            if self.disk_tables.is_empty() || self.disk_tables.len() == 1 {
+                // The table are empty or already compacted, there is nothing to do
+                return Ok(());
+            }
         }
 
         // Create single temporary sorted string file by iterating over all entries

--- a/core/src/util/disk_collections.rs
+++ b/core/src/util/disk_collections.rs
@@ -38,8 +38,7 @@ pub enum EvictionStrategy {
 
 impl Default for EvictionStrategy {
     fn default() -> Self {
-        // Use up to 60 MB for the C0 in-memory before purging the data onto disk
-        EvictionStrategy::MaximumBytes(60 * MB)
+        EvictionStrategy::MaximumBytes(32 * MB)
     }
 }
 
@@ -84,7 +83,7 @@ where
         if let Some(persisted_file) = persisted_file {
             if persisted_file.is_file() {
                 // Use existing file as read-only table which contains the whole map
-                let table = Table::new_from_file(custom_options(), persisted_file)?;
+                let table = Table::new_from_file(sstable::Options::default(), persisted_file)?;
                 disk_tables.push(table);
             }
         }

--- a/core/src/util/disk_collections.rs
+++ b/core/src/util/disk_collections.rs
@@ -186,7 +186,10 @@ where
             };
 
             {
-                let mut builder = TableBuilder::new(sstable::Options::default(), &out_file);
+                let mut builder = TableBuilder::new(
+                    sstable::Options::default().with_cache_capacity(1),
+                    &out_file,
+                );
 
                 for (key, value) in self.c0.iter() {
                     let key = key.create_key();
@@ -200,7 +203,7 @@ where
             self.est_sum_memory = 0;
             let size = out_file.metadata()?.len();
             let table = Table::new(
-                sstable::Options::default(),
+                sstable::Options::default().with_cache_capacity(1),
                 Box::new(out_file),
                 size as usize,
             )?;
@@ -479,7 +482,10 @@ where
 
         // Create single temporary sorted string file by iterating over all entries
         let out_file = tempfile::tempfile()?;
-        let mut builder = TableBuilder::new(sstable::Options::default(), &out_file);
+        let mut builder = TableBuilder::new(
+            sstable::Options::default().with_cache_capacity(1),
+            &out_file,
+        );
         for (key, value) in self.try_iter()? {
             let key = key.create_key();
             builder.add(&key, &self.serialization.serialize(&Some(value))?)?;
@@ -513,7 +519,8 @@ where
             .read(true)
             .create(true)
             .open(&location)?;
-        let mut builder = TableBuilder::new(sstable::Options::default(), out_file);
+        let mut builder =
+            TableBuilder::new(sstable::Options::default().with_cache_capacity(1), out_file);
         for (key, value) in self.try_iter()? {
             let key = key.create_key();
             builder.add(&key, &self.serialization.serialize(&Some(value))?)?;

--- a/docs/src/cli.md
+++ b/docs/src/cli.md
@@ -32,6 +32,12 @@ You can also import a ZIP file (having the file ending `.zip`) to import multipl
 ZIP files can contain a mixture of relANNIS and graphML files.
 They also have the benefit of compression, which can be especially useful for the XML-based graphML format.
 
+Per default, graphANNIS will keep the whole corpus in main memory for faster query execution.
+You can enable the **"disk-based"** mode for a corpus by executing the command `set-disk-based on` before the 
+import command. This will use much less main memory when loading a corpus, but will also cause slower query execution.
+Please note that you will still need at least 4 GB of main memory during import for larger corpora even when
+this option is on, because of internal caching (memory usage will be less for querying the corpus).
+
 ### `list`
 
 To list the names of all imported corpora, use the `list` command.

--- a/graphannis/src/annis/db/relannis.rs
+++ b/graphannis/src/annis/db/relannis.rs
@@ -802,21 +802,16 @@ fn get_field<'a>(
     }
 }
 
-fn escape_field<'a>(val: &str) -> Cow<str> {
+fn escape_field<'a>(val: &'a str) -> Cow<'a, str> {
     ESCAPE_PATTERN.replace_all(val, |caps: &Captures| {
         if let Some(c) = caps.get(1) {
             match c.as_str() {
-                "n" => Cow::Borrowed("\n"),
-                "t" => Cow::Borrowed("\t"),
-                "\\" => Cow::Borrowed("\\"),
-                "'" => Cow::Borrowed("'"),
-                "$" => Cow::Borrowed("$"),
-                // Fallback, since this allocates the string avoid using
-                // it and better use the static strings like above
-                _ => Cow::Owned(c.as_str().to_string()),
+                "n" => "\n",
+                "t" => "\t",
+                _ => val,
             }
         } else {
-            Cow::Borrowed("")
+            ""
         }
     })
 }

--- a/graphannis/src/annis/db/relannis.rs
+++ b/graphannis/src/annis/db/relannis.rs
@@ -376,9 +376,12 @@ where
 
         // TODO: implement handling the "virtual_tokenization_from_namespace" and "virtual_tokenization_mapping" corpus properties
 
+        progress_callback("calculating node statistics (before update)");
+        db.get_node_annos_mut().calculate_statistics();
+
         db.apply_update(&mut updates, &progress_callback)?;
 
-        progress_callback("calculating node statistics");
+        progress_callback("calculating node statistics (after update)");
         db.get_node_annos_mut().calculate_statistics();
 
         for c in db.get_all_components(None, None) {

--- a/graphannis/src/annis/db/relannis.rs
+++ b/graphannis/src/annis/db/relannis.rs
@@ -808,6 +808,11 @@ fn escape_field<'a>(val: &str) -> Cow<str> {
             match c.as_str() {
                 "n" => Cow::Borrowed("\n"),
                 "t" => Cow::Borrowed("\t"),
+                "\\" => Cow::Borrowed("\\"),
+                "'" => Cow::Borrowed("'"),
+                "$" => Cow::Borrowed("$"),
+                // Fallback, since this allocates the string avoid using
+                // it and better use the static strings like above
                 _ => Cow::Owned(c.as_str().to_string()),
             }
         } else {

--- a/graphannis/src/annis/errors.rs
+++ b/graphannis/src/annis/errors.rs
@@ -64,6 +64,8 @@ pub enum GraphAnnisError {
     Csv(#[from] csv::Error),
     #[error(transparent)]
     ParseIntError(#[from] std::num::ParseIntError),
+    #[error(transparent)]
+    RegexError(#[from] regex::Error),
 }
 
 #[derive(Error, Debug)]

--- a/graphannis/src/annis/errors.rs
+++ b/graphannis/src/annis/errors.rs
@@ -64,8 +64,6 @@ pub enum GraphAnnisError {
     Csv(#[from] csv::Error),
     #[error(transparent)]
     ParseIntError(#[from] std::num::ParseIntError),
-    #[error(transparent)]
-    RegexError(#[from] regex::Error),
 }
 
 #[derive(Error, Debug)]

--- a/graphannis/src/annis/util/mod.rs
+++ b/graphannis/src/annis/util/mod.rs
@@ -1,5 +1,7 @@
 pub mod quicksort;
 
+use graphannis_core::serializer::KeyVec;
+
 use crate::errors::{GraphAnnisError, Result};
 
 use std::{
@@ -19,8 +21,8 @@ pub fn contains_regex_metacharacters(pattern: &str) -> bool {
 /// Creates a byte array key from a vector of strings.
 ///
 /// The strings are terminated with `\0`.
-pub fn create_str_vec_key(val: &[&str]) -> Vec<u8> {
-    let mut result: Vec<u8> = Vec::default();
+pub fn create_str_vec_key(val: &[&str]) -> KeyVec {
+    let mut result: KeyVec = KeyVec::default();
     for v in val {
         // append null-terminated string to result
         for b in v.as_bytes() {


### PR DESCRIPTION
- Limit the used main memory cache per `DiskTable` to about 100MB in the default configuration.
  Since we use a lot of disk-based maps during import of relANNIS files, this can add up to > 1GB easily.
  The maximum cache usage was much larger before, which amongst other issues caused #205 to happen.
  With this change, during relANNIS import the main memory usage should be limited to be less than 4GB, 
  which seams more reasonable than the previous 20+GB
- Reduce memory footprint during import when corpus contains a lot of escaped strings (as in #205)
- Avoid creating small fragmented main memory when importing corpora from relANNIS to help to fix #205