### PR TITLE
Fix timeout handling for queries with a lot of intermediate results, but less than 1000 matches.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Actually apply timeout for `find` and `count` queries with less than 1000
+  matches. The timeout was only checked after each 1000th match. This caused
+  troubles for queries with complex temporary results that where discarded. The
+  query execution could take too long time and consume system resources in a
+  multi-user system even when the timeout was configured. The fix is to push
+  down the timeout check to the node search iterators.
+
 ## [2.0.4] - 2022-04-22
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Actually apply timeout for `find` and `count` queries with less than 1000
-  matches. The timeout was only checked after each 1000th match. This caused
-  troubles for queries with complex temporary results that where discarded. The
-  query execution could take too long time and consume system resources in a
-  multi-user system even when the timeout was configured. The fix is to push
-  down the timeout check to the node search iterators.
+- Fix timeout handling for queries with a lot of intermediate results, but less
+  than 1000 matches. The timeout was only checked after each 1000th match. This
+  caused troubles for queries with complex temporary results that where
+  discarded. The query execution could take too long time and consume system
+  resources in a multi-user system even when the timeout was configured. The fix
+  is to push down the timeout check to the node search iterators.
 
 ## [2.0.4] - 2022-04-22
 

--- a/graphannis/src/annis/db/aql/conjunction/tests.rs
+++ b/graphannis/src/annis/db/aql/conjunction/tests.rs
@@ -11,6 +11,7 @@ use crate::{
             plan::ExecutionPlan,
         },
         errors::GraphAnnisError::AQLSemanticError,
+        util::TimeoutCheck,
     },
     AnnotationGraph,
 };
@@ -145,7 +146,7 @@ fn semantic_error_unbound() {
     let g = AnnotationGraph::with_default_graphstorages(false).unwrap();
     // No syntax error
     let q = aql::parse("tok & tok", false).unwrap();
-    let plan = ExecutionPlan::from_disjunction(&q, &g, &config);
+    let plan = ExecutionPlan::from_disjunction(&q, &g, &config, TimeoutCheck::new(None));
     match plan {
         Err(AQLSemanticError(err)) => assert_eq!(
             "Variable \"#2\" not bound (use linguistic operators)",

--- a/graphannis/src/annis/db/aql/operators/non_existing.rs
+++ b/graphannis/src/annis/db/aql/operators/non_existing.rs
@@ -21,6 +21,7 @@ use crate::{
             BinaryOperator, BinaryOperatorBase, BinaryOperatorIndex, BinaryOperatorSpec,
             EstimationType, UnaryOperator, UnaryOperatorSpec,
         },
+        util::TimeoutCheck,
     },
     AnnotationGraph,
 };
@@ -213,7 +214,13 @@ impl<'a> Display for NonExistingUnaryOperatorFilter<'a> {
 impl<'a> UnaryOperator for NonExistingUnaryOperatorFilter<'a> {
     fn filter_match(&self, m: &graphannis_core::annostorage::Match) -> Result<bool> {
         // The candidate match is on one side and we need to get an iterator of all possible matches for the other side
-        if let Ok(node_search) = NodeSearch::from_spec(self.target.clone(), 0, self.graph, None) {
+        if let Ok(node_search) = NodeSearch::from_spec(
+            self.target.clone(),
+            0,
+            self.graph,
+            None,
+            TimeoutCheck::new(None),
+        ) {
             // Include if no nodes matches the conditions
             if self.target_left {
                 for lhs in node_search {

--- a/graphannis/src/annis/db/plan.rs
+++ b/graphannis/src/annis/db/plan.rs
@@ -1,6 +1,7 @@
 use crate::annis::db::aql::disjunction::Disjunction;
 use crate::annis::db::aql::Config;
 use crate::annis::db::exec::{EmptyResultSet, ExecutionNode, ExecutionNodeDesc};
+use crate::annis::util::TimeoutCheck;
 use crate::AnnotationGraph;
 use crate::{annis::errors::*, graph::Match};
 use graphannis_core::{
@@ -26,12 +27,13 @@ impl<'a> ExecutionPlan<'a> {
         query: &'a Disjunction,
         db: &'a AnnotationGraph,
         config: &Config,
+        timeout: TimeoutCheck,
     ) -> Result<ExecutionPlan<'a>> {
         let mut plans: Vec<Box<dyn ExecutionNode<Item = Result<MatchGroup>> + 'a>> = Vec::new();
         let mut descriptions = Vec::new();
         let mut inverse_node_pos = Vec::new();
         for alt in &query.alternatives {
-            let p = alt.make_exec_node(db, config);
+            let p = alt.make_exec_node(db, config, timeout);
             if let Ok(p) = p {
                 descriptions.push(p.get_desc().cloned());
 

--- a/graphannis/src/annis/util/mod.rs
+++ b/graphannis/src/annis/util/mod.rs
@@ -116,7 +116,13 @@ impl TimeoutCheck {
     /// Check if too much time was used and return an error if this is the case.
     pub fn check(&self) -> Result<()> {
         if let Some(timeout) = self.timeout {
-            if self.start_time.elapsed() > timeout {
+            let elapsed = self.start_time.elapsed();
+            if elapsed > timeout {
+                debug!(
+                    "Timeout reached after {} ms (configured for {} ms)",
+                    elapsed.as_millis(),
+                    timeout.as_millis()
+                );
                 return Err(GraphAnnisError::Timeout);
             }
         }


### PR DESCRIPTION
The timeout was only checked after each 1000th match. This
  caused troubles for queries with complex temporary results that where
  discarded. The query execution could take too long time and consume system
  resources in a multi-user system even when the timeout was configured. The fix
  is to push down the timeout check to the node search iterators.