### PR TITLE
sort metadata corpus properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Allow to configure the expected display order of (sub)-corpus meta annotations
+  using the `corpus_annotation_order` field in the view configuration.
+
 ## [2.1.0] - 2022-05-31
 
 ### Added

--- a/graphannis/src/annis/types.rs
+++ b/graphannis/src/annis/types.rs
@@ -117,9 +117,15 @@ pub struct ViewConfiguration {
     pub base_text_segmentation: Option<String>,
     /// Default number of results to show at once for paginated queries.
     pub page_size: usize,
-    // A list of fully qualified annotation names that should be hidden when displayed.
+    /// A list of fully qualified annotation names that should be hidden when displayed.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub hidden_annos: Vec<String>,
+    /// A sorted list of fully qualified annotation names. When showing
+    /// (metadata) annotations for a (sub)-corpus, the given annotations should
+    /// be displayed first and in the given order. Annotations not listed should
+    /// be appended in alphabetical order to the given entries.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub corpus_annotation_order: Vec<String>,
 }
 
 impl Default for ViewConfiguration {
@@ -128,6 +134,7 @@ impl Default for ViewConfiguration {
             base_text_segmentation: None,
             page_size: 10,
             hidden_annos: Vec::default(),
+            corpus_annotation_order: Vec::default(),
         }
     }
 }

--- a/webservice/src/openapi.yml
+++ b/webservice/src/openapi.yml
@@ -996,6 +996,16 @@ components:
               items:
                 type: string
               description: A list of fully qualified annotation names that should be hidden when displayed.
+            corpus_annotation_order:
+              type: array
+              items:
+                type: string
+              description: >
+                A sorted list of fully qualified annotation names. When showing
+                (metadata) annotations for a (sub)-corpus, the given annotations
+                should be displayed first and in the given order. Annotations
+                not listed should be appended in alphabetical order to the given
+                entries.
         example_queries:
           type: array
           description: An array of example queries for the corpus with a description.


### PR DESCRIPTION
This is used in the ANNIS frontend to change the displayed order of the metadata fields