### PR TITLE
Add GitHub action to report code coverage on a PR

### DIFF
--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: ref-lcov.info
-          path: ./target/coverage/lcov.info
+          path: ./target/coverage/tests.lcov
 
   checks:
     runs-on: ubuntu-latest
@@ -93,7 +93,7 @@ jobs:
         uses: barecheck/code-coverage-action@v1
         with:
           barecheck-github-app-token: ${{ secrets.BARECHECK_GITHUB_APP_TOKEN }}
-          lcov-file: "./target/coverage/lcov.info"
+          lcov-file: "./target/coverage/tests.lcov"
           base-lcov-file: "./lcov.info"
           minimum-ratio: 0 # Fails Github action once code coverage is decreasing
           send-summary-comment: true

--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -13,7 +13,12 @@ jobs:
         with:
           toolchain: stable
           profile: minimal
+          components: llvm-tools-preview
       - uses: Swatinem/rust-cache@v1.3.0
+      - uses: SierraSoftworks/setup-grcov@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          version: latest
       - uses: actions/cache@v2
         id: corpus-cache
         with:
@@ -60,7 +65,12 @@ jobs:
         with:
           toolchain: stable
           profile: minimal
+          components: llvm-tools-preview
       - uses: Swatinem/rust-cache@v1.3.0
+      - uses: SierraSoftworks/setup-grcov@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          version: latest
       - uses: actions/cache@v2
         id: corpus-cache
         with:

--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -1,0 +1,100 @@
+name: Code Coverage
+
+on: [pull_request]
+
+jobs:
+  base_branch_cov:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ github.base_ref }}
+      - uses: actions-rs/toolchain@v1.0.6
+        with:
+          toolchain: stable
+          profile: minimal
+      - uses: Swatinem/rust-cache@v1.3.0
+      - uses: actions/cache@v2
+        id: corpus-cache
+        with:
+          path: |
+            relannis
+            data
+            data_ondisk
+          key: ${{ runner.os }}-search-v1-compatible-${{ hashFiles('graphannis/tests/searchtest.rs','graphannis/tests/searchtest_queries.csv', 'graphannis/build.rs') }}
+      - name: Download test corpora
+        if: steps.corpus-cache.outputs.cache-hit != 'true'
+        run: test -d relannis/GUM/ -a -d relannis/pcc2.1/ -a -d relannis/subtok.demo || "./misc/download-test-corpora.sh"
+      - name: Build CLI binary
+        if: steps.corpus-cache.outputs.cache-hit != 'true'
+        run: cargo build --release --bin annis
+      - name: Import GUM corpus (memory)
+        if: steps.corpus-cache.outputs.cache-hit != 'true'
+        run: ./target/release/annis data --cmd 'import relannis/GUM'
+      - name: Import pcc2.1 corpus (memory)
+        if: steps.corpus-cache.outputs.cache-hit != 'true'
+        run: ./target/release/annis data --cmd 'import relannis/pcc2.1'
+      - name: Import subtok.demo corpus (memory)
+        if: steps.corpus-cache.outputs.cache-hit != 'true'
+        run: ./target/release/annis data --cmd 'import relannis/subtok.demo'
+      - name: Run tests with code coverage
+        run: misc/test_coverage.sh
+
+      - name: Upload code coverage for ref branch
+        uses: actions/upload-artifact@v2
+        with:
+          name: ref-lcov.info
+          path: ./target/coverage/lcov.info
+
+  checks:
+    runs-on: ubuntu-latest
+    needs: base_branch_cov
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download code coverage report from base branch
+        uses: actions/download-artifact@v2
+        with:
+          name: ref-lcov.info
+
+      - uses: actions-rs/toolchain@v1.0.6
+        with:
+          toolchain: stable
+          profile: minimal
+      - uses: Swatinem/rust-cache@v1.3.0
+      - uses: actions/cache@v2
+        id: corpus-cache
+        with:
+          path: |
+            relannis
+            data
+            data_ondisk
+          key: ${{ runner.os }}-search-v1-compatible-${{ hashFiles('graphannis/tests/searchtest.rs','graphannis/tests/searchtest_queries.csv', 'graphannis/build.rs') }}
+      - name: Download test corpora
+        if: steps.corpus-cache.outputs.cache-hit != 'true'
+        run: test -d relannis/GUM/ -a -d relannis/pcc2.1/ -a -d relannis/subtok.demo || "./misc/download-test-corpora.sh"
+      - name: Build CLI binary
+        if: steps.corpus-cache.outputs.cache-hit != 'true'
+        run: cargo build --release --bin annis
+      - name: Import GUM corpus (memory)
+        if: steps.corpus-cache.outputs.cache-hit != 'true'
+        run: ./target/release/annis data --cmd 'import relannis/GUM'
+      - name: Import pcc2.1 corpus (memory)
+        if: steps.corpus-cache.outputs.cache-hit != 'true'
+        run: ./target/release/annis data --cmd 'import relannis/pcc2.1'
+      - name: Import subtok.demo corpus (memory)
+        if: steps.corpus-cache.outputs.cache-hit != 'true'
+        run: ./target/release/annis data --cmd 'import relannis/subtok.demo'
+      - name: Run tests with code coverage
+        run: misc/test_coverage.sh
+
+      #  Compares two code coverage files and generates report as a comment
+      - name: Generate Code Coverage report
+        id: code-coverage
+        uses: barecheck/code-coverage-action@v1
+        with:
+          barecheck-github-app-token: ${{ secrets.BARECHECK_GITHUB_APP_TOKEN }}
+          lcov-file: "./target/coverage/lcov.info"
+          base-lcov-file: "./lcov.info"
+          minimum-ratio: 0 # Fails Github action once code coverage is decreasing
+          send-summary-comment: true
+          show-annotations: "warning" # Possible options warning|error

--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -20,13 +20,13 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           version: latest
       - uses: actions/cache@v2
-        id: corpus-cache
+        id: code-coverage-corpus-cache
         with:
           path: |
             relannis
             data
             data_ondisk
-          key: ${{ runner.os }}-search-v1-compatible-${{ hashFiles('graphannis/tests/searchtest.rs','graphannis/tests/searchtest_queries.csv', 'graphannis/build.rs') }}
+          key: ${{ runner.os }}-codecov-${{ hashFiles('graphannis/tests/searchtest.rs','graphannis/tests/searchtest_queries.csv', 'graphannis/build.rs') }}
       - name: Download test corpora
         if: steps.corpus-cache.outputs.cache-hit != 'true'
         run: test -d relannis/GUM/ -a -d relannis/pcc2.1/ -a -d relannis/subtok.demo || "./misc/download-test-corpora.sh"
@@ -72,13 +72,13 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           version: latest
       - uses: actions/cache@v2
-        id: corpus-cache
+        id: code-coverage-corpus-cache
         with:
           path: |
             relannis
             data
             data_ondisk
-          key: ${{ runner.os }}-search-v1-compatible-${{ hashFiles('graphannis/tests/searchtest.rs','graphannis/tests/searchtest_queries.csv', 'graphannis/build.rs') }}
+          key: ${{ runner.os }}-codecov-${{ hashFiles('graphannis/tests/searchtest.rs','graphannis/tests/searchtest_queries.csv', 'graphannis/build.rs') }}
       - name: Download test corpora
         if: steps.corpus-cache.outputs.cache-hit != 'true'
         run: test -d relannis/GUM/ -a -d relannis/pcc2.1/ -a -d relannis/subtok.demo || "./misc/download-test-corpora.sh"

--- a/.github/workflows/code_coverage.yml
+++ b/.github/workflows/code_coverage.yml
@@ -104,7 +104,7 @@ jobs:
         with:
           barecheck-github-app-token: ${{ secrets.BARECHECK_GITHUB_APP_TOKEN }}
           lcov-file: "./target/coverage/tests.lcov"
-          base-lcov-file: "./lcov.info"
+          base-lcov-file: "./tests.lcov"
           minimum-ratio: 0 # Fails Github action once code coverage is decreasing
           send-summary-comment: true
           show-annotations: "warning" # Possible options warning|error

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,7 +65,7 @@ jobs:
             relannis
             data
             data_ondisk
-          key: ${{ runner.os }}-search-v1-compatible-${{ hashFiles('graphannis/tests/searchtest.rs','graphannis/tests/searchtest_queries.csv', 'graphannis/build.rs') }}
+          key: ${{ runner.os }}-search-compatible-${{ hashFiles('graphannis/tests/searchtest.rs','graphannis/tests/searchtest_queries.csv', 'graphannis/build.rs') }}
       - name: Download test corpora
         if: steps.corpus-cache.outputs.cache-hit != 'true'
         run: test -d relannis/GUM/ -a -d relannis/pcc2.1/ -a -d relannis/subtok.demo || "./misc/download-test-corpora.sh"
@@ -98,5 +98,5 @@ jobs:
       - name: Run integration tests (ondisk)
         run: cargo test --release -- --ignored
         working-directory: graphannis
-        env: 
+        env:
           ANNIS4_TEST_DATA: "../data_ondisk"

--- a/misc/test_coverage.sh
+++ b/misc/test_coverage.sh
@@ -14,9 +14,9 @@ LLVM_PROFILE_FILE='cargo-test-%p-%m.profraw' cargo test
 LLVM_PROFILE_FILE='cargo-ignored-test-%p-%m.profraw' cargo test -- --ignored
 
 # Generate HTML report in target/debug/coverage/index.html
-grcov . --binary-path ./target/debug/deps/ -s . -t html --branch --ignore-not-existing --ignore '../*' --ignore "/*" -o target/coverage/html/
+grcov . --binary-path ./target/debug/deps/ -s . -t html --branch --ignore-not-existing --ignore '*/tests/*' --ignore 'target/*' --ignore '../*' --ignore "/*" -o target/coverage/html/
 # Also generate a lcov file for further processing
-grcov . --binary-path ./target/debug/deps/ -s . -t lcov --branch --ignore-not-existing --ignore '../*' --ignore "/*" -o target/coverage/tests.lcov
+grcov . --binary-path ./target/debug/deps/ -s . -t lcov --branch --ignore-not-existing --ignore '*/tests/*' --ignore 'target/*'  --ignore '../*' --ignore "/*" -o target/coverage/tests.lcov
 
 # Cleanup
 find . -name '*.profraw' -delete


### PR DESCRIPTION
This uses the barcheck.com GitHub application for now, but it should be possible to adapt it to other providers.

Code coverage is measured using the helper script and compared to a baseline on main.