### PR TITLE
Allow to execute AQL directly on loaded `AnnotationGraph` objects.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Allow to execute AQL directly on loaded `AnnotationGraph` objects by using the
+  new `aql::execute_query_on_graph` and `aql::parse` functions. This is an
+  alternative for using a `CorpusStorage` when only one corpus is handled.
 - New `Graph::ensure_loaded_parallel` function to load needed graph storages in
   parallel.
 

--- a/graphannis/src/annis/db/aql/disjunction.rs
+++ b/graphannis/src/annis/db/aql/disjunction.rs
@@ -3,16 +3,17 @@ use crate::{annis::db::aql::model::AnnotationComponentType, AnnotationGraph};
 use graphannis_core::types::Component;
 use std::collections::HashSet;
 
+/// A disjunction is a parsed and normalized AQL query.
 pub struct Disjunction {
-    pub alternatives: Vec<Conjunction>,
+    pub(crate) alternatives: Vec<Conjunction>,
 }
 
 impl Disjunction {
-    pub fn new(alternatives: Vec<Conjunction>) -> Disjunction {
+    pub(crate) fn new(alternatives: Vec<Conjunction>) -> Disjunction {
         Disjunction { alternatives }
     }
 
-    pub fn necessary_components(
+    pub(crate) fn necessary_components(
         &self,
         db: &AnnotationGraph,
     ) -> HashSet<Component<AnnotationComponentType>> {
@@ -26,7 +27,7 @@ impl Disjunction {
         result
     }
 
-    pub fn get_variable_pos(&self, variable: &str) -> Option<usize> {
+    pub(crate) fn get_variable_pos(&self, variable: &str) -> Option<usize> {
         for alt in &self.alternatives {
             if let Ok(var_pos) = alt.resolve_variable_pos(variable, None) {
                 return Some(var_pos);
@@ -40,7 +41,7 @@ impl Disjunction {
     /// Optional nodes that are not part of the output are ignored. If there are
     /// no optional nodes, this corresponds to the index of the node in the
     /// query.
-    pub fn get_variable_by_pos(&self, pos: usize) -> Option<String> {
+    pub(crate) fn get_variable_by_pos(&self, pos: usize) -> Option<String> {
         for alt in &self.alternatives {
             if let Some(var) = alt.get_variable_by_pos(pos) {
                 return Some(var);

--- a/graphannis/src/annis/db/aql/mod.rs
+++ b/graphannis/src/annis/db/aql/mod.rs
@@ -646,3 +646,23 @@ fn extract_location<'a>(
     };
     from_to
 }
+
+#[cfg(test)]
+mod tests {
+    use std::{fs::File, path::PathBuf};
+
+    use super::*;
+
+    #[test]
+    fn query_on_annotation_graph() {
+        let cargo_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let input_file = File::open(&cargo_dir.join("tests/SaltSampleCorpus.graphml")).unwrap();
+        let (graph, _config_str): (AnnotationGraph, _) =
+            graphannis_core::graph::serialization::graphml::import(input_file, false, |_status| {})
+                .unwrap();
+
+        let query = parse("tok @* annis:doc=\"doc4\"", false).unwrap();
+        let it = execute_query_on_graph(&graph, &query, true, None).unwrap();
+        assert_eq!(11, it.count());
+    }
+}

--- a/graphannis/src/annis/db/aql/mod.rs
+++ b/graphannis/src/annis/db/aql/mod.rs
@@ -5,6 +5,7 @@ pub mod model;
 pub mod operators;
 
 use boolean_expression::Expr;
+use graphannis_core::annostorage::MatchGroup;
 lalrpop_mod!(
     #[allow(clippy::all)]
     #[allow(clippy::panic)]
@@ -19,13 +20,17 @@ use crate::annis::db::aql::operators::{
     PartOfSubCorpusSpec, RangeSpec,
 };
 use crate::annis::db::exec::nodesearch::NodeSearchSpec;
+use crate::annis::db::plan::ExecutionPlan;
 use crate::annis::errors::*;
 use crate::annis::operator::{BinaryOperatorSpec, UnaryOperatorSpec};
 use crate::annis::types::{LineColumn, LineColumnRange};
+use crate::annis::util::TimeoutCheck;
+use crate::AnnotationGraph;
 use lalrpop_util::ParseError;
 use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 
 thread_local! {
     static AQL_PARSER: parser::DisjunctionParser = parser::DisjunctionParser::new();
@@ -34,6 +39,47 @@ thread_local! {
 #[derive(Clone, Default, Debug)]
 pub struct Config {
     pub use_parallel_joins: bool,
+}
+
+/// Executes an query on an [`AnnotationGraph`](AnnotationGraph)
+/// and return an iterator over the results.
+///
+/// The results are not guaranteed to be sorted in any way and it is assumed
+/// that the graph is fully loaded.
+///
+/// # Example
+///
+/// ```
+/// use graphannis::*;
+///
+/// let graph = AnnotationGraph::with_default_graphstorages(false)?;
+/// let query = aql::parse("tok", false)?;
+/// let it = aql::execute_query_on_graph(&graph, &query, true, None)?;
+/// assert_eq!(0, it.count());
+///
+/// # Ok::<(), graphannis::errors::GraphAnnisError>(())
+/// ```
+///
+pub fn execute_query_on_graph<'a>(
+    graph: &'a AnnotationGraph,
+    query: &'a Disjunction,
+    use_parallel_joins: bool,
+    timeout: Option<Duration>,
+) -> Result<Box<dyn Iterator<Item = Result<MatchGroup>> + 'a>> {
+    // Check that all components are loaded
+    for c in graph.get_all_components(None, None) {
+        let gs = graph.get_graphstorage_as_ref(&c);
+        if gs.is_none() {
+            return Err(GraphAnnisError::QueriedGraphNotFullyLoaded);
+        }
+    }
+
+    let timeout = TimeoutCheck::new(timeout);
+
+    let config = Config { use_parallel_joins };
+    let it = ExecutionPlan::from_disjunction(query, graph, &config, timeout)?;
+
+    Ok(Box::from(it))
 }
 
 fn map_conjunction(
@@ -418,6 +464,14 @@ fn get_alternatives_from_dnf(expr: ast::Expr) -> Vec<Vec<ast::Literal>> {
     vec![]
 }
 
+/// Parses an AQL query from a string.
+///
+/// # Arguments
+///
+/// * `query_as_aql` - Textual representation of the AQL query
+/// * `quirks_mode` -  If `true`, emulates the (sometimes problematic) behavior
+///   of AQL used in ANNIS 3
+///
 pub fn parse(query_as_aql: &str, quirks_mode: bool) -> Result<Disjunction> {
     let ast = AQL_PARSER.with(|p| p.parse(query_as_aql));
     match ast {

--- a/graphannis/src/annis/db/corpusstorage.rs
+++ b/graphannis/src/annis/db/corpusstorage.rs
@@ -1289,7 +1289,7 @@ impl CorpusStorage {
 
     /// Creates a new empty corpus with the given name.
     ///
-    /// Use [`apply_update`] to add elements to the corpus. Returns whether a
+    /// Use [`apply_update`](CorpusStorage::apply_update) to add elements to the corpus. Returns whether a
     /// new corpus was created.
     pub fn create_empty_corpus(&self, corpus_name: &str, disk_based: bool) -> Result<bool> {
         let mut cache_lock = self.corpus_cache.write()?;

--- a/graphannis/src/annis/errors.rs
+++ b/graphannis/src/annis/errors.rs
@@ -79,6 +79,8 @@ pub enum GraphAnnisError {
     BtreeIndex(#[from] transient_btree_index::Error),
     #[error("index out of bounds {0}")]
     IndexOutOfBounds(usize),
+    #[error("The annotation graph that shall be queried is not fully loaded.")]
+    QueriedGraphNotFullyLoaded,
 }
 
 impl<T> From<PoisonError<T>> for GraphAnnisError {

--- a/graphannis/src/lib.rs
+++ b/graphannis/src/lib.rs
@@ -45,7 +45,7 @@ pub use graphannis_core::graph::update;
 
 pub use graphannis_core::graph::Graph;
 
-/// A specialization of the [`Graph`](struct.Graph.html), using components needed to represent and query corpus annotation graphs.
+/// A specialization of the [`Graph`], using components needed to represent and query corpus annotation graphs.
 pub type AnnotationGraph =
     graphannis_core::graph::Graph<annis::db::aql::model::AnnotationComponentType>;
 
@@ -64,6 +64,13 @@ pub mod model {
     pub use crate::annis::db::aql::model::AnnotationComponentType;
     pub type AnnotationComponent =
         graphannis_core::types::Component<crate::model::AnnotationComponentType>;
+}
+
+/// Helper functions to execute AQL queries on an [`AnnotationGraph`].
+pub mod aql {
+    pub use crate::annis::db::aql::disjunction::Disjunction;
+    pub use crate::annis::db::aql::execute_query_on_graph;
+    pub use crate::annis::db::aql::parse;
 }
 
 /// Contains the graphANNIS-specific error types.


### PR DESCRIPTION
This API is an alternative for using a `CorpusStorage` when only one corpus is handled and adds the new functions `aql::execute_query_on_graph` and `aql::parse` functions.

```rust
use graphannis::*;

let graph = AnnotationGraph::with_default_graphstorages(false)?;
let query = aql::parse("tok", false)?;
let it = aql::execute_query_on_graph(&graph, &query, true, None)?;
assert_eq!(0, it.count());
```