### PR TITLE
Fix leaf filter for token searches

### DIFF
--- a/graphannis/src/annis/db/exec/nodesearch.rs
+++ b/graphannis/src/annis/db/exec/nodesearch.rs
@@ -231,6 +231,7 @@ impl NodeSearchSpec {
                         Ok(false)
                     }
                 }));
+                filters.push(create_token_leaf_filter(g));
             }
             NodeSearchSpec::RegexTokenValue { val, leafs_only } => {
                 let full_match_pattern = graphannis_core::util::regex_full_match(val);
@@ -272,6 +273,7 @@ impl NodeSearchSpec {
                         }));
                     }
                 };
+                filters.push(create_token_leaf_filter(g));
             }
             NodeSearchSpec::AnyToken => {
                 filters.push(create_token_leaf_filter(g));

--- a/graphannis/src/annis/db/exec/nodesearch.rs
+++ b/graphannis/src/annis/db/exec/nodesearch.rs
@@ -90,10 +90,21 @@ impl NodeSearchSpec {
         &self,
         db: &AnnotationGraph,
     ) -> HashSet<Component<AnnotationComponentType>> {
-        if let NodeSearchSpec::AnyToken = self {
-            return tokensearch::AnyTokenSearch::necessary_components(db);
+        match self {
+            NodeSearchSpec::AnyToken => tokensearch::AnyTokenSearch::necessary_components(db),
+            NodeSearchSpec::ExactTokenValue {
+                leafs_only: true, ..
+            }
+            | NodeSearchSpec::RegexTokenValue {
+                leafs_only: true, ..
+            }
+            | NodeSearchSpec::NotExactTokenValue { .. }
+            | NodeSearchSpec::NotRegexTokenValue { .. } => db
+                .get_all_components(Some(AnnotationComponentType::Coverage), None)
+                .into_iter()
+                .collect(),
+            _ => HashSet::default(),
         }
-        HashSet::default()
     }
 
     /// Get the annotatiom qualified name needed to execute a search with this specification.

--- a/graphannis/tests/searchtest.rs
+++ b/graphannis/tests/searchtest.rs
@@ -293,3 +293,26 @@ fn token_search_loads_components_for_leaf_filter() {
         }
     }
 }
+
+#[ignore]
+#[test]
+fn negative_token_search_applies_leaf_filter() {
+    if let Some(cs) = CORPUS_STORAGE.as_ref() {
+        // `node_name=/.*/` causes the token query to become the RHS of the join
+        for (query, expected_count) in [
+            ("node_name=/.*/ _ident_ tok!=\"example\"", 10),
+            ("node_name=/.*/ _ident_ tok!=/example/", 10),
+        ] {
+            let query = SearchQuery {
+                corpus_names: &["subtok.demo"],
+                query,
+                query_language: QueryLanguage::AQL,
+                timeout: None,
+            };
+
+            let count = cs.count(query).unwrap();
+
+            assert_eq!(count, expected_count);
+        }
+    }
+}

--- a/graphannis/tests/searchtest.rs
+++ b/graphannis/tests/searchtest.rs
@@ -266,3 +266,30 @@ fn meta_node_output_standard() {
         result
     );
 }
+
+#[ignore]
+#[test]
+fn token_search_loads_components_for_leaf_filter() {
+    if let Some(cs) = CORPUS_STORAGE.as_ref() {
+        for (query, expected_count) in [
+            ("tok", 11),
+            ("tok=\"example\"", 1),
+            ("tok=/example/", 1),
+            ("tok!=\"example\"", 10),
+            ("tok!=/example/", 10),
+        ] {
+            let query = SearchQuery {
+                corpus_names: &["subtok.demo"],
+                query,
+                query_language: QueryLanguage::AQL,
+                timeout: None,
+            };
+
+            // Unload corpus to test that query loads components necessary to filter for leaves
+            cs.unload("subtok.demo").unwrap();
+            let count = cs.count(query).unwrap();
+
+            assert_eq!(count, expected_count);
+        }
+    }
+}


### PR DESCRIPTION
I found two minor issues concerning the leaf filter (i.e. filtering for nodes without outgoing coverage edges) when running a token search.

## Loading the necessary components
While `AnyToken` explicitly loads the components necessary to apply the leaf filter, `ExactTokenValue`, `NotExactTokenValue`, `RegexTokenValue` and `NotRegexTokenValue` don't. Consequently, the leaf filter isn't applied unless the components happen to be loaded already.

This can be reproduced e.g. via the ANNIS web GUI:
1. Import the [subtok.demo](https://corpus-tools.org/corpora/subtok.demo_relANNIS.zip) corpus
2. Start a fresh instance (so that no components are loaded yet)
3. Query for `tok="example"`, using an order of `NotSorted` or `Randomized` (this is necessary because `Normal` and `Inverted` happen to load the necessary components)
4. Observe that you get 3 results, but then 1 result when running the query for a second time

## Applying the leaf filter for negative token searches
`NotExactTokenValue` and `NotRegexTokenValue` apply the leaf filter only when they are the LHS of a join, not when they are the RHS.

This can be reproduced e.g. via the ANNIS web GUI:
1. Import the [subtok.demo](https://corpus-tools.org/corpora/subtok.demo_relANNIS.zip) corpus
2. Query for `tok!="example"` and observe that you correctly get 10 results (leaf filter is applied)
3. Query for `tok!="example" _ident_ node_name=/.*/` and observe that you incorrectly get 28 results (leaf filter is not applied because the additional condition, which should have no effect, causes the token search to become the RHS of the join)

This seems to be similar to https://github.com/korpling/graphANNIS/issues/46.