### PR TITLE
Fix find output for optional nodes not at the end of the AQL query

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,65 +1,48 @@
 {
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "type": "lldb",
-            "request": "attach",
-            "name": "Attach",
-            "pid": "${command:pickMyProcess}", // use ${command:pickProcess} to pick other users' processes
-            "sourceLanguages": [
-                "rust"
-            ]
-        },
-        {
-            "type": "lldb",
-            "request": "launch",
-            "name": "Console",
-            "program": "${workspaceRoot}/target/debug/annis",
-            "args": [
-                "data"
-            ],
-            "cwd": "${workspaceRoot}",
-            "terminal": "integrated",
-            "env": {
-                "RUST_BACKTRACE": "1"
-            },
-            "sourceLanguages": [
-                "rust"
-            ]
-        },
-        {
-            "type": "lldb",
-            "request": "launch",
-            "name": "Web Service",
-            "program": "${workspaceRoot}/target/debug/graphannis-webservice",
-            "args": [
-                "--config",
-                "${workspaceRoot}/tmp/test.toml"
-            ],
-            "cwd": "${workspaceRoot}/webservice/",
-            "terminal": "integrated",
-            "env": {
-                "RUST_BACKTRACE": "1"
-            },
-            "sourceLanguages": [
-                "rust"
-            ]
-        },
-        {
-            "type": "lldb",
-            "request": "launch",
-            "name": "Debug Test",
-            "cargo": {
-                "args": [
-                    "test",
-                    "--no-run",
-                    "--lib"
-                ]
-            },
-            "sourceLanguages": [
-                "rust"
-            ],
-            "cwd": "${workspaceRoot}"
-        }
-    ]
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "lldb",
+      "request": "attach",
+      "name": "Attach",
+      "pid": "${command:pickMyProcess}", // use ${command:pickProcess} to pick other users' processes
+      "sourceLanguages": ["rust"]
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Console",
+      "program": "${workspaceRoot}/target/debug/annis",
+      "args": ["/home/thomas/.annis/v4/"],
+      "cwd": "${workspaceRoot}",
+      "terminal": "integrated",
+      "env": {
+        "RUST_BACKTRACE": "1"
+      },
+      "sourceLanguages": ["rust"]
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Web Service",
+      "program": "${workspaceRoot}/target/debug/graphannis-webservice",
+      "args": ["--config", "${workspaceRoot}/tmp/test.toml"],
+      "cwd": "${workspaceRoot}/webservice/",
+      "terminal": "integrated",
+      "env": {
+        "RUST_BACKTRACE": "1"
+      },
+      "sourceLanguages": ["rust"]
+    },
+    {
+      "type": "lldb",
+      "request": "launch",
+      "name": "Debug Test",
+      "cargo": {
+        "args": ["test", "--no-run", "--lib"]
+      },
+      "sourceLanguages": ["rust"],
+      "cwd": "${workspaceRoot}"
+    }
+  ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- When optional nodes where located not at the end but somewhere in between the
+  query, the output of the `find` query could include the wrong node ID.
+
 ## [3.3.0] - 2024-05-27
 
 ### Changed

--- a/graphannis/src/annis/db/aql/conjunction.rs
+++ b/graphannis/src/annis/db/aql/conjunction.rs
@@ -75,7 +75,6 @@ pub struct Conjunction {
     variables: HashMap<String, usize>,
     location_in_query: HashMap<String, LineColumnRange>,
     variable_included_in_output: HashSet<String>,
-    position_included_in_output: HashSet<usize>,
     var_idx_offset: usize,
 }
 
@@ -235,7 +234,7 @@ impl Conjunction {
             variables: HashMap::default(),
             location_in_query: HashMap::default(),
             variable_included_in_output: HashSet::default(),
-            position_included_in_output: HashSet::default(),
+
             var_idx_offset: 0,
         }
     }
@@ -248,7 +247,7 @@ impl Conjunction {
             variables: HashMap::default(),
             location_in_query: HashMap::default(),
             variable_included_in_output: HashSet::default(),
-            position_included_in_output: HashSet::default(),
+
             var_idx_offset,
         }
     }
@@ -305,11 +304,11 @@ impl Conjunction {
         self.variables.insert(variable.clone(), idx);
         if included_in_output && !optional {
             self.variable_included_in_output.insert(variable.clone());
-            self.position_included_in_output.insert(idx);
         }
         if let Some(location) = location {
             self.location_in_query.insert(variable.clone(), location);
         }
+
         variable
     }
 
@@ -387,20 +386,14 @@ impl Conjunction {
         self.variable_included_in_output.contains(variable)
     }
 
-    /// Returns true if the node at given position in the query should be included in the output.
-    pub(crate) fn position_included_in_output(&self, idx: usize) -> bool {
-        self.position_included_in_output.contains(&idx)
-    }
-
     /// Return the variable name for a given position in the match output list.
     ///
-    /// Optional nodes that are not part of the output are ignored. If there are
-    /// no optional nodes, this corresponds to the index of the node in the
-    /// query.
-    pub fn get_variable_by_pos(&self, pos: usize) -> Option<String> {
+    /// Optional nodes  are ignored. If there are no optional nodes, this
+    /// corresponds to the index of the node in the query.
+    pub fn get_variable_by_match_pos(&self, pos: usize) -> Option<String> {
         let mut output_pos = 0;
         for n in self.nodes.iter() {
-            if self.variable_included_in_output(&n.var) {
+            if !n.optional {
                 if output_pos == pos {
                     return Some(n.var.clone());
                 }

--- a/graphannis/src/annis/db/aql/disjunction.rs
+++ b/graphannis/src/annis/db/aql/disjunction.rs
@@ -36,13 +36,26 @@ impl Disjunction {
         None
     }
 
-    /// Returns true if the node at given position in the query should be included in the output for all alternatives.
-    pub(crate) fn position_included_in_output(&self, idx: usize) -> bool {
+    /// Return the variable name for a given position in the match output list.
+    ///
+    /// Optional nodes  are ignored. If there are no optional nodes, this
+    /// corresponds to the index of the node in the query.
+    pub(crate) fn get_variable_by_match_pos(&self, pos: usize) -> Option<String> {
         for alt in &self.alternatives {
-            if !alt.position_included_in_output(idx) {
-                return false;
+            if let Some(var) = alt.get_variable_by_match_pos(pos) {
+                return Some(var);
             }
         }
-        true
+        None
+    }
+
+    /// Returns true if the node at given by the variable name should be included in the output.
+    pub(crate) fn variable_included_in_output(&self, variable: &str) -> bool {
+        for alt in &self.alternatives {
+            if alt.variable_included_in_output(variable) {
+                return true;
+            }
+        }
+        false
     }
 }

--- a/graphannis/src/annis/db/aql/disjunction.rs
+++ b/graphannis/src/annis/db/aql/disjunction.rs
@@ -36,17 +36,13 @@ impl Disjunction {
         None
     }
 
-    /// Return the variable name for a given position in the match output list.
-    ///
-    /// Optional nodes that are not part of the output are ignored. If there are
-    /// no optional nodes, this corresponds to the index of the node in the
-    /// query.
-    pub(crate) fn get_variable_by_pos(&self, pos: usize) -> Option<String> {
+    /// Returns true if the node at given position in the query should be included in the output for all alternatives.
+    pub(crate) fn position_included_in_output(&self, idx: usize) -> bool {
         for alt in &self.alternatives {
-            if let Some(var) = alt.get_variable_by_pos(pos) {
-                return Some(var);
+            if !alt.position_included_in_output(idx) {
+                return false;
             }
         }
-        None
+        true
     }
 }

--- a/graphannis/src/annis/db/aql/mod.rs
+++ b/graphannis/src/annis/db/aql/mod.rs
@@ -502,7 +502,7 @@ pub fn parse(query_as_aql: &str, quirks_mode: bool) -> Result<Disjunction> {
 
                 if quirks_mode {
                     // apply the meta constraints from all conjunctions to conjunctions
-                    let first_node_pos = mapped.get_variable_by_pos(0);
+                    let first_node_pos = mapped.get_variable_by_match_pos(0);
                     add_legacy_metadata_constraints(
                         &mut mapped,
                         legacy_meta_search.clone(),

--- a/graphannis/src/annis/db/corpusstorage.rs
+++ b/graphannis/src/annis/db/corpusstorage.rs
@@ -1910,7 +1910,7 @@ impl CorpusStorage {
 
             for (i, singlematch) in m.iter().enumerate() {
                 // check if query node actually should be included
-                let include_in_output = prep.query.get_variable_by_pos(i).is_some();
+                let include_in_output = prep.query.position_included_in_output(i);
 
                 if include_in_output {
                     if i > 0 {

--- a/graphannis/src/annis/db/corpusstorage.rs
+++ b/graphannis/src/annis/db/corpusstorage.rs
@@ -1908,12 +1908,19 @@ impl CorpusStorage {
             let m = m?;
             let mut match_desc = String::new();
 
-            for (i, singlematch) in m.iter().enumerate() {
-                // check if query node actually should be included
-                let include_in_output = prep.query.position_included_in_output(i);
+            for (match_pos, singlematch) in m.iter().enumerate() {
+                // Check if query node actually should be included. There are
+                // nodes like the meta queries that are included in the plan,
+                // but are not part of the find query result. These have been
+                // marked as "do not include" when they have been added and can
+                // be skipped.
+                let include_in_output = prep
+                    .query
+                    .get_variable_by_match_pos(match_pos)
+                    .map_or(false, |var| prep.query.variable_included_in_output(&var));
 
                 if include_in_output {
-                    if i > 0 {
+                    if match_pos > 0 {
                         match_desc.push(' ');
                     }
 

--- a/graphannis/src/annis/db/exec/mod.rs
+++ b/graphannis/src/annis/db/exec/mod.rs
@@ -23,7 +23,8 @@ pub struct ExecutionNodeDesc {
     pub component_nr: usize,
     pub lhs: Option<Box<ExecutionNodeDesc>>,
     pub rhs: Option<Box<ExecutionNodeDesc>>,
-    /// Maps the index of the node in the actual result to the index in the internal execution plan intermediate result.
+    /// Maps the index of the node in the actual result to the index in the
+    /// internal execution plan intermediate result.
     pub node_pos: BTreeMap<usize, usize>,
     pub impl_description: String,
     pub query_fragment: String,

--- a/graphannis/tests/searchtest.rs
+++ b/graphannis/tests/searchtest.rs
@@ -269,6 +269,54 @@ fn meta_node_output_standard() {
 
 #[ignore]
 #[test]
+fn exclude_optional_node_in_between() {
+    let cs = CORPUS_STORAGE.as_ref().unwrap();
+
+    let q = SearchQuery {
+        corpus_names: &["GUM"],
+        query: r#"entity="person" !_o_ q? & infstat="giv" & #1 _r_ #3"#,
+        query_language: QueryLanguage::AQL,
+        timeout: None,
+    };
+    let result = cs
+        .find(
+            q.clone(),
+            0,
+            Some(1),
+            graphannis::corpusstorage::ResultOrder::Normal,
+        )
+        .unwrap();
+
+    // Only node #1 and #3 should be part of the output
+    assert_eq!(vec!["ref::entity::GUM/GUM_interview_ants#referent_291 ref::infstat::GUM/GUM_interview_ants#referent_321"], result);
+}
+
+#[ignore]
+#[test]
+fn exclude_optional_node_at_end() {
+    let cs = CORPUS_STORAGE.as_ref().unwrap();
+
+    let q = SearchQuery {
+        corpus_names: &["GUM"],
+        query: r#"entity="person" _r_ infstat="giv" &  q? & #1 !_o_ #3"#,
+        query_language: QueryLanguage::AQL,
+        timeout: None,
+    };
+    let result = cs
+        .find(
+            q.clone(),
+            0,
+            Some(1),
+            graphannis::corpusstorage::ResultOrder::Normal,
+        )
+        .unwrap();
+
+    // Only node #1 and #2 should be part of the output
+    assert_eq!(vec!["ref::entity::GUM/GUM_interview_ants#referent_291 ref::infstat::GUM/GUM_interview_ants#referent_321"], result);
+}
+
+#[ignore]
+#[test]
 fn token_search_loads_components_for_leaf_filter() {
     if let Some(cs) = CORPUS_STORAGE.as_ref() {
         for (query, expected_count) in [

--- a/graphannis/tests/searchtest_queries.csv
+++ b/graphannis/tests/searchtest_queries.csv
@@ -46,6 +46,8 @@ NonExistingLeftInv,"/""/? !_l_ quote",GUM,11
 NonExistingRight,"quote & /""/? & #1 !_r_ #2",GUM,19
 NonExistingRightInv,"quote & /""/? & #2 !_r_ #1",GUM,19
 InvalidNonExisting,"tok !. tok? !_o_  node?",GUM,0
+OptionalQueryNodeAtEnd,"entity=""person"" _r_ infstat=""giv"" &  q? & #1 !_o_ #3",GUM,2404
+OptionalQueryNodeInBetween,"entity=""person"" !_o_ q? & infstat=""giv"" & #1 _r_ #3",GUM,2404
 NotDocument,"tok @* doc!=""maz-11299""",pcc2.1,34709
 StructureInclusionSeed,"cat=""S"" _i_ cat=""AP""",pcc2.1,726
 IsConnectedRange,"""Jugendlichen"" .3,10 ""Musikcafé""",pcc2.1,1

--- a/graphannis/tests/searchtest_queries.csv
+++ b/graphannis/tests/searchtest_queries.csv
@@ -48,6 +48,7 @@ NonExistingRightInv,"quote & /""/? & #2 !_r_ #1",GUM,19
 InvalidNonExisting,"tok !. tok? !_o_  node?",GUM,0
 OptionalQueryNodeAtEnd,"entity=""person"" _r_ infstat=""giv"" &  q? & #1 !_o_ #3",GUM,2404
 OptionalQueryNodeInBetween,"entity=""person"" !_o_ q? & infstat=""giv"" & #1 _r_ #3",GUM,2404
+OptionalQueryAlternative,"(entity=""person"" !_o_ q? & infstat=""giv"" & #1 _r_ #3) | (entity=""organization"" !_o_ q? & infstat=""new"" & #1 _r_ #3)",GUM,2702
 NotDocument,"tok @* doc!=""maz-11299""",pcc2.1,34709
 StructureInclusionSeed,"cat=""S"" _i_ cat=""AP""",pcc2.1,726
 IsConnectedRange,"""Jugendlichen"" .3,10 ""Musikcafé""",pcc2.1,1


### PR DESCRIPTION
This is a better fix for #267, which was assumed to be fixed before but the original fix was incomplete.
