### PR TITLE
Fix regression parsing legacy meta queries with multiple alternatives

### DIFF
--- a/graphannis/src/annis/db/aql/mod.rs
+++ b/graphannis/src/annis/db/aql/mod.rs
@@ -499,7 +499,7 @@ pub fn parse(query_as_aql: &str, quirks_mode: bool) -> Result<Disjunction> {
 
                 if quirks_mode {
                     // apply the meta constraints to first node of all conjunctions
-                    let first_node_var = mapped.get_variable_by_node_nr(0);
+                    let first_node_var = mapped.get_variable_by_node_nr(var_idx_offset);
                     add_legacy_metadata_constraints(
                         &mut mapped,
                         legacy_meta_search.clone(),

--- a/graphannis/tests/searchtest.rs
+++ b/graphannis/tests/searchtest.rs
@@ -388,3 +388,21 @@ fn no_error_on_large_token_distance() {
 
     assert_eq!(0, result.len());
 }
+
+#[ignore]
+#[test]
+fn legacy_meta_query_with_multiple_alternatives() {
+    let cs = CORPUS_STORAGE.as_ref().unwrap();
+
+    // "buy" and "favorite" each appear exactly once in type="interview" and once in type="news"
+    let query = SearchQuery {
+        corpus_names: &["GUM"],
+        query: "\"buy\" | \"favorite\" & meta::type=\"interview\"",
+        query_language: QueryLanguage::AQLQuirksV3,
+        timeout: None,
+    };
+
+    let count = cs.count(query).unwrap();
+
+    assert_eq!(count, 2);
+}


### PR DESCRIPTION
I found a small regression introduced in https://github.com/korpling/graphANNIS/pull/299/commits/f87bd0dd5849bb30f671c40397871077d1116be5: When a legacy meta query has multiple alternatives, the meta constraints are supposed to be added to the first node of each alternative, but are in fact only added to the first node of the *first* alternative. This is because `get_variable_by_node_nr` now expects a node number relative to the whole query, but is still always called with 0, which is only correct for the first alternative. This leads to an out-of-bounds error later in `make_exec_plan_with_order`.