### PR TITLE
Add support for partitioned GraphML files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Make the `graph::serizalization::read_graphml` function of the
+  `graphannis-core` crate public. This is useful in case you want to do collect
+  updates from a GraphML-file without generating a `Graph` directly.
+
 ## [4.1.5] - 2026-06-25
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Make the `graph::serizalization::read_graphml` function of the
   `graphannis-core` crate public. This is useful in case you want to do collect
   updates from a GraphML-file without generating a `Graph` directly.
+- Add `is_disk_based` method to `Graph`.
 
 ## [4.1.5] - 2026-06-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Handle partitioned GraphML files in CorpusStorage.
 - Make the `graph::serizalization::read_graphml` function of the
   `graphannis-core` crate public. This is useful in case you want to do collect
   updates from a GraphML-file without generating a `Graph` directly.

--- a/cli/src/bin/annis.rs
+++ b/cli/src/bin/annis.rs
@@ -338,7 +338,7 @@ impl AnnisRunner {
         if let Ok(t) = load_time {
             info!(
                 "exported corpora {:?} in {}",
-                &self.current_corpus,
+                self.current_corpus,
                 format_dhms(t.as_secs())
             );
         }
@@ -451,7 +451,7 @@ impl AnnisRunner {
                     ));
                 }
             };
-            println!("New result order is \"{:?}\"", &self.result_order);
+            println!("New result order is \"{:?}\"", self.result_order);
         }
         Ok(())
     }

--- a/core/src/dfs.rs
+++ b/core/src/dfs.rs
@@ -71,14 +71,14 @@ impl<'a> CycleSafeDFS<'a> {
         if self.last_distance >= dist {
             // remove all entries below the parent node from the path
             for i in dist..self.path.len() {
-                trace!("truncating {} from path", &self.path[i]);
+                trace!("truncating {} from path", self.path[i]);
                 self.nodes_in_path.remove(&self.path[i]);
             }
             self.path.truncate(dist);
         }
         // test for cycle
         if self.nodes_in_path.contains(&node) {
-            trace!("cycle detected for node {} with distance {}", &node, dist);
+            trace!("cycle detected for node {} with distance {}", node, dist);
             self.last_distance = dist;
             self.cycle_detected = true;
             trace!("removing from stack because of cycle");

--- a/core/src/graph/mod.rs
+++ b/core/src/graph/mod.rs
@@ -414,7 +414,7 @@ impl<CT: ComponentType> Graph<CT> {
         progress_callback(&format!("applying {} atomic updates", total_nr_updates));
         for (nr_updates, update_event) in u.iter()?.enumerate() {
             let (id, change) = update_event?;
-            trace!("applying event {:?}", &change);
+            trace!("applying event {:?}", change);
             ComponentType::before_update_event(&change, self, &mut update_graph_index)?;
             match &change {
                 UpdateEvent::AddNode {
@@ -710,7 +710,7 @@ impl<CT: ComponentType> Graph<CT> {
                 debug!("writing WAL update log to {:?}", temporary_disk_file.path());
                 bincode::serialize_into(temporary_disk_file.as_file(), &u)?;
                 temporary_disk_file.flush()?;
-                debug!("moving finished WAL update log to {:?}", &log_path);
+                debug!("moving finished WAL update log to {:?}", log_path);
                 // Since the temporary file should be on the same file system, persisting/moving it should be an atomic operation
                 temporary_disk_file.persist(&log_path)?;
 
@@ -718,7 +718,7 @@ impl<CT: ComponentType> Graph<CT> {
             } else {
                 trace!(
                     "error occured while applying updates: {:?}",
-                    &apply_update_result
+                    apply_update_result
                 );
                 // load corpus from disk again
                 self.open(&location)?;
@@ -819,7 +819,7 @@ impl<CT: ComponentType> Graph<CT> {
         debug!("Calculating node statistics");
         self.node_annos.calculate_statistics()?;
         for c in self.get_all_components(None, None) {
-            debug!("Calculating statistics for component {}", &c);
+            debug!("Calculating statistics for component {}", c);
             self.calculate_component_statistics(&c)?;
         }
 
@@ -922,7 +922,7 @@ impl<CT: ComponentType> Graph<CT> {
                 debug!(
                     "loading component {} from {}",
                     c,
-                    &component_path.to_string_lossy()
+                    component_path.to_string_lossy()
                 );
                 let component = load_component_from_disk(&component_path)?;
                 gs_opt.get_or_insert_with(|| component);
@@ -960,7 +960,7 @@ impl<CT: ComponentType> Graph<CT> {
                     debug!(
                         "loading component in parallel {} from {}",
                         c,
-                        &cpath.to_string_lossy()
+                        cpath.to_string_lossy()
                     );
                     (c, load_component_from_disk(&cpath))
                 }
@@ -1010,7 +1010,7 @@ impl<CT: ComponentType> Graph<CT> {
 
         for c in self.get_all_components(None, None) {
             // Perform the optimization if necessary
-            info!("optimizing implementation for component {}", &c);
+            info!("optimizing implementation for component {}", c);
             self.optimize_gs_impl(&c)?;
         }
         if let Some(location) = &self.location {

--- a/core/src/graph/mod.rs
+++ b/core/src/graph/mod.rs
@@ -1130,6 +1130,11 @@ impl<CT: ComponentType> Graph<CT> {
             filtered_components.collect()
         }
     }
+
+    /// Returns `true` if  disk-based annotation and graph storages are prefered instead of memory-only ones.
+    pub fn is_disk_based(&self) -> bool {
+        self.disk_based
+    }
 }
 
 #[cfg(test)]

--- a/core/src/graph/serialization/graphml.rs
+++ b/core/src/graph/serialization/graphml.rs
@@ -17,8 +17,9 @@ use quick_xml::{
 };
 use std::{
     cmp::Ordering,
-    collections::{BTreeMap, BTreeSet, HashMap},
+    collections::{BTreeMap, BTreeSet, HashMap, VecDeque},
     io::{BufReader, BufWriter, Read, Write},
+    path::{Path, PathBuf},
     str::FromStr,
 };
 
@@ -245,6 +246,57 @@ pub fn read_graphml<CT: ComponentType, R: std::io::BufRead, F: Fn(&str)>(
         buf.clear();
     }
     Ok(config)
+}
+
+/// A corpus can consist of several GraphML-files if the corpus is partitioned
+/// and there is a subdirectory with the same name as the basename of the
+/// GraphML file given as argument.
+///
+/// This function finds the files that belong the same corpus for and returns
+/// the paths in the order they should be read. If there is no matching
+/// subdirectory next to the given GraphML-file, the file itself is returned.
+pub fn files_for_corpus<P: AsRef<Path>>(file: P) -> Result<Vec<PathBuf>> {
+    let mut result = Vec::new();
+    if file.as_ref().is_file()
+        && let Some(ext) = file.as_ref().extension()
+        && ext == "graphml"
+    {
+        // Add the root GraphML file first
+        result.push(file.as_ref().to_path_buf());
+
+        // If there is a directory with the same base name as the GraphML file,
+        // search this directory with a BFS for more GraphML-files
+        if let Some(parent_dir) = file.as_ref().parent()
+            && let Some(basename) = file.as_ref().file_stem()
+            && let corpus_dir = parent_dir.join(basename)
+            && corpus_dir.is_dir()
+        {
+            let mut queue = VecDeque::new();
+            queue.push_back(corpus_dir);
+
+            while let Some(current_file) = queue.pop_front() {
+                if current_file.is_dir() {
+                    // Get all files and directories that belong to this parent
+                    // directory and add them to the queue in a predicatble order.
+                    let mut same_level_entries = BTreeMap::new();
+                    for dir_entry in std::fs::read_dir(&current_file)? {
+                        let dir_entry = dir_entry?;
+                        same_level_entries.insert(dir_entry.file_name(), dir_entry.path());
+                    }
+
+                    for p in same_level_entries.into_values() {
+                        queue.push_back(p);
+                    }
+                } else if current_file.is_file()
+                    && let Some(extension) = current_file.extension()
+                    && extension == "graphml"
+                {
+                    result.push(current_file);
+                }
+            }
+        }
+    }
+    Ok(result)
 }
 
 /// Export the GraphML file without any guarantuee on the order of the XML elements.
@@ -891,5 +943,36 @@ value = "test""#;
         );
 
         assert_eq!(Some(TEST_CONFIG), config_str.as_deref());
+    }
+
+    #[test]
+    fn test_partitioned_file_import_order() {
+        let example_corpus = Path::new("tests/partioned-graphml/single_sentence.graphml");
+        assert!(example_corpus.is_file());
+
+        let result = files_for_corpus(example_corpus).unwrap();
+        assert_eq!(3, result.len());
+        assert_eq!(
+            "tests/partioned-graphml/single_sentence.graphml",
+            result[0].to_string_lossy()
+        );
+        assert_eq!(
+            "tests/partioned-graphml/single_sentence/zossen.graphml",
+            result[1].to_string_lossy()
+        );
+        assert_eq!(
+            "tests/partioned-graphml/single_sentence/subcorpus1/anotherdocument.graphml",
+            result[2].to_string_lossy()
+        );
+    }
+
+    #[test]
+    fn test_non_partitioned_file_import_order() {
+        let example_corpus = Path::new("tests/single_sentence.graphml");
+        assert!(example_corpus.is_file());
+
+        let result = files_for_corpus(example_corpus).unwrap();
+        assert_eq!(1, result.len());
+        assert_eq!("tests/single_sentence.graphml", result[0].to_string_lossy());
     }
 }

--- a/core/src/graph/serialization/graphml.rs
+++ b/core/src/graph/serialization/graphml.rs
@@ -22,6 +22,364 @@ use std::{
     str::FromStr,
 };
 
+/// Import a GraphML-file as an annotation [`Graph`].
+///
+/// # Returns
+///
+/// A tuple of the graph itself and an optional corpus configuration as string.
+pub fn import<CT: ComponentType, R: Read, F>(
+    input: R,
+    disk_based: bool,
+    progress_callback: F,
+) -> Result<(Graph<CT>, Option<String>)>
+where
+    F: Fn(&str),
+{
+    // Always buffer the read operations
+    let mut input = BufReader::new(input);
+    let mut g = Graph::with_default_graphstorages(disk_based)?;
+    let mut updates = GraphUpdate::default();
+    let mut edge_updates = GraphUpdate::default();
+
+    // read in all nodes and edges, collecting annotation keys on the fly
+    progress_callback("reading GraphML");
+    let config = read_graphml::<CT, BufReader<R>, F>(
+        &mut input,
+        &mut updates,
+        &mut edge_updates,
+        &progress_callback,
+    )?;
+
+    // Append all edges updates after the node updates:
+    // edges would not be added if the nodes they are referring do not exist
+    progress_callback("merging generated events");
+    for event in edge_updates.iter()? {
+        let (_, event) = event?;
+        updates.add_event(event)?;
+    }
+
+    progress_callback("applying imported changes");
+    g.apply_update(&mut updates, &progress_callback)?;
+
+    progress_callback("calculating graph statistics");
+    g.calculate_all_statistics()?;
+
+    for c in g.get_all_components(None, None) {
+        progress_callback(&format!("optimizing implementation for component {}", c));
+        g.optimize_gs_impl(&c)?;
+    }
+
+    Ok((g, config))
+}
+
+/// Read in a single GraphML file from `input` and fill the updates given as
+/// parameters.
+///
+/// In order to create a [`Graph`] from it, you first have to apply the
+/// `node_updates` and then the `edge_updates`. Status updates can be retrieved
+/// by the `progress_updates` closure, that will be called with a message as
+/// argument and can be used e.g. for logging or displaying the status message
+/// to the user.
+///
+/// # Returns
+///
+/// If the GraphML-file contains a corpus configuration, this is returned as a string.
+pub fn read_graphml<CT: ComponentType, R: std::io::BufRead, F: Fn(&str)>(
+    input: &mut R,
+    node_updates: &mut GraphUpdate,
+    edge_updates: &mut GraphUpdate,
+    progress_callback: &F,
+) -> Result<Option<String>> {
+    let mut reader = Reader::from_reader(input);
+    reader.expand_empty_elements(true);
+
+    let mut keys = BTreeMap::new();
+
+    let mut level = 0;
+    let mut in_graph = false;
+    let mut current_node_id: Option<String> = None;
+    let mut current_data_key: Option<String> = None;
+    let mut current_source_id: Option<String> = None;
+    let mut current_target_id: Option<String> = None;
+    let mut current_component: Option<String> = None;
+    let mut current_data_value: Option<String> = None;
+    let mut data: HashMap<AnnoKey, String> = HashMap::new();
+
+    let mut config = None;
+
+    let mut processed_updates = 0;
+
+    let mut buf = Vec::new();
+    loop {
+        match reader.read_event_into(&mut buf)? {
+            Event::Start(ref e) => {
+                level += 1;
+
+                match e.name().0 {
+                    b"graph" if level == 2 => {
+                        in_graph = true;
+                    }
+                    b"key" if level == 2 => {
+                        add_annotation_key(&mut keys, e.attributes())?;
+                    }
+                    b"node" if in_graph && level == 3 => {
+                        data.clear();
+                        // Get the ID of this node
+                        for att in e.attributes() {
+                            let att = att?;
+                            if att.key.0 == b"id" {
+                                current_node_id =
+                                    Some(String::from_utf8_lossy(&att.value).to_string());
+                            }
+                        }
+                    }
+
+                    b"edge" if in_graph && level == 3 => {
+                        data.clear();
+                        // Get the source and target node IDs
+                        for att in e.attributes() {
+                            let att = att?;
+                            if att.key.0 == b"source" {
+                                current_source_id =
+                                    Some(String::from_utf8_lossy(&att.value).to_string());
+                            } else if att.key.0 == b"target" {
+                                current_target_id =
+                                    Some(String::from_utf8_lossy(&att.value).to_string());
+                            } else if att.key.0 == b"label" {
+                                current_component =
+                                    Some(String::from_utf8_lossy(&att.value).to_string());
+                            }
+                        }
+                    }
+
+                    b"data" => {
+                        for att in e.attributes() {
+                            let att = att?;
+                            if att.key.0 == b"key" {
+                                current_data_key =
+                                    Some(String::from_utf8_lossy(&att.value).to_string());
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            Event::Text(t) if in_graph && level == 4 && current_data_key.is_some() => {
+                current_data_value = Some(t.unescape()?.to_string());
+            }
+
+            Event::CData(t) => {
+                if let Some(current_data_key) = &current_data_key
+                    && in_graph
+                    && level == 3
+                    && current_data_key == "k0"
+                {
+                    // This is the configuration content
+                    config = Some(String::from_utf8_lossy(&t).to_string());
+                }
+            }
+            Event::End(ref e) => {
+                match e.name().0 {
+                    b"graph" => {
+                        in_graph = false;
+                    }
+                    b"node" => {
+                        add_node(node_updates, &current_node_id, &mut data)?;
+                        current_node_id = None;
+                        processed_updates += 1;
+                        if processed_updates % 1_000_000 == 0 {
+                            progress_callback(&format!(
+                                "Processed {} GraphML nodes and edges",
+                                processed_updates
+                            ));
+                        }
+                    }
+                    b"edge" => {
+                        add_edge::<CT>(
+                            edge_updates,
+                            &current_source_id,
+                            &current_target_id,
+                            &current_component,
+                            &mut data,
+                        )?;
+                        current_source_id = None;
+                        current_target_id = None;
+                        current_component = None;
+                        processed_updates += 1;
+                        if processed_updates % 1_000_000 == 0 {
+                            progress_callback(&format!(
+                                "Processed {} GraphML nodes and edges",
+                                processed_updates
+                            ));
+                        }
+                    }
+                    b"data" => {
+                        if let Some(current_data_key) = current_data_key
+                            && let Some(anno_key) = keys.get(&current_data_key)
+                        {
+                            // Copy all data attributes into our own map
+                            if let Some(v) = current_data_value.take() {
+                                data.insert(anno_key.clone(), v);
+                            } else {
+                                // If there is an end tag without any text
+                                // data event, the value exists but is
+                                // empty.
+                                data.insert(anno_key.clone(), String::default());
+                            }
+                        }
+
+                        current_data_value = None;
+                        current_data_key = None;
+                    }
+                    _ => {}
+                }
+
+                level -= 1;
+            }
+            Event::Eof => {
+                break;
+            }
+            _ => {}
+        }
+        // Clear the buffer after each event
+        buf.clear();
+    }
+    Ok(config)
+}
+
+/// Export the GraphML file without any guarantuee on the order of the XML elements.
+///
+/// This is faster than  than [`export_stable_order`].
+pub fn export<CT: ComponentType, W: std::io::Write, F>(
+    graph: &Graph<CT>,
+    graph_configuration: Option<&str>,
+    output: W,
+    progress_callback: F,
+) -> Result<()>
+where
+    F: Fn(&str),
+{
+    // Always buffer the output
+    let output = BufWriter::new(output);
+    let mut writer = Writer::new_with_indent(output, b' ', 4);
+
+    // Add XML declaration
+    let xml_decl = BytesDecl::new("1.0", Some("UTF-8"), None);
+    writer.write_event(Event::Decl(xml_decl))?;
+
+    // Always write the root element
+    writer.write_event(Event::Start(BytesStart::new("graphml")))?;
+
+    // Define all valid annotation ns/name pairs
+    progress_callback("exporting all available annotation keys");
+    let key_id_mapping =
+        write_annotation_keys(graph, graph_configuration.is_some(), false, &mut writer)?;
+
+    // We are writing a single graph
+    let mut graph_start = BytesStart::new("graph");
+    graph_start.push_attribute(("edgedefault", "directed"));
+    // Add parse helper information to allow more efficient parsing
+    graph_start.push_attribute(("parse.order", "nodesfirst"));
+    graph_start.push_attribute(("parse.nodeids", "free"));
+    graph_start.push_attribute(("parse.edgeids", "canonical"));
+
+    writer.write_event(Event::Start(graph_start))?;
+
+    // If graph configuration is given, add it as data element to the graph
+    if let Some(config) = graph_configuration {
+        let mut data_start = BytesStart::new("data");
+        // This is always the first key ID
+        data_start.push_attribute(("key", "k0"));
+        writer.write_event(Event::Start(data_start))?;
+        // Add the annotation value as internal text node
+        writer.write_event(Event::CData(BytesCData::new(config)))?;
+        writer.write_event(Event::End(BytesEnd::new("data")))?;
+    }
+
+    // Write out all nodes
+    progress_callback("exporting nodes");
+    write_nodes(graph, &mut writer, false, &key_id_mapping)?;
+
+    // Write out all edges
+    progress_callback("exporting edges");
+    write_edges(graph, &mut writer, false, &key_id_mapping)?;
+
+    writer.write_event(Event::End(BytesEnd::new("graph")))?;
+    writer.write_event(Event::End(BytesEnd::new("graphml")))?;
+
+    // Make sure to flush the buffered writer
+    writer.into_inner().flush()?;
+
+    Ok(())
+}
+
+/// Export the GraphML file and ensure a stable order of the XML elements.
+///
+/// This is slower than [`export`] but can e.g. be used in tests where the
+/// output should always be the same.
+pub fn export_stable_order<CT: ComponentType, W: std::io::Write, F>(
+    graph: &Graph<CT>,
+    graph_configuration: Option<&str>,
+    output: W,
+    progress_callback: F,
+) -> Result<()>
+where
+    F: Fn(&str),
+{
+    // Always buffer the output
+    let output = BufWriter::new(output);
+    let mut writer = Writer::new_with_indent(output, b' ', 4);
+
+    // Add XML declaration
+    let xml_decl = BytesDecl::new("1.0", Some("UTF-8"), None);
+    writer.write_event(Event::Decl(xml_decl))?;
+
+    // Always write the root element
+    writer.write_event(Event::Start(BytesStart::new("graphml")))?;
+
+    // Define all valid annotation ns/name pairs
+    progress_callback("exporting all available annotation keys");
+    let key_id_mapping =
+        write_annotation_keys(graph, graph_configuration.is_some(), true, &mut writer)?;
+
+    // We are writing a single graph
+    let mut graph_start = BytesStart::new("graph");
+    graph_start.push_attribute(("edgedefault", "directed"));
+    // Add parse helper information to allow more efficient parsing
+    graph_start.push_attribute(("parse.order", "nodesfirst"));
+    graph_start.push_attribute(("parse.nodeids", "free"));
+    graph_start.push_attribute(("parse.edgeids", "canonical"));
+
+    writer.write_event(Event::Start(graph_start))?;
+
+    // If graph configuration is given, add it as data element to the graph
+    if let Some(config) = graph_configuration {
+        let mut data_start = BytesStart::new("data");
+        // This is always the first key ID
+        data_start.push_attribute(("key", "k0"));
+        writer.write_event(Event::Start(data_start))?;
+        // Add the annotation value as internal text node
+        writer.write_event(Event::CData(BytesCData::new(config)))?;
+        writer.write_event(Event::End(BytesEnd::new("data")))?;
+    }
+
+    // Write out all nodes
+    progress_callback("exporting nodes");
+    write_nodes(graph, &mut writer, true, &key_id_mapping)?;
+
+    // Write out all edges
+    progress_callback("exporting edges");
+    write_edges(graph, &mut writer, true, &key_id_mapping)?;
+
+    writer.write_event(Event::End(BytesEnd::new("graph")))?;
+    writer.write_event(Event::End(BytesEnd::new("graphml")))?;
+
+    // Make sure to flush the buffered writer
+    writer.into_inner().flush()?;
+
+    Ok(())
+}
+
 fn write_annotation_keys<CT: ComponentType, W: std::io::Write>(
     graph: &Graph<CT>,
     has_graph_configuration: bool,
@@ -277,136 +635,6 @@ fn write_edges<CT: ComponentType, W: std::io::Write>(
     Ok(())
 }
 
-pub fn export<CT: ComponentType, W: std::io::Write, F>(
-    graph: &Graph<CT>,
-    graph_configuration: Option<&str>,
-    output: W,
-    progress_callback: F,
-) -> Result<()>
-where
-    F: Fn(&str),
-{
-    // Always buffer the output
-    let output = BufWriter::new(output);
-    let mut writer = Writer::new_with_indent(output, b' ', 4);
-
-    // Add XML declaration
-    let xml_decl = BytesDecl::new("1.0", Some("UTF-8"), None);
-    writer.write_event(Event::Decl(xml_decl))?;
-
-    // Always write the root element
-    writer.write_event(Event::Start(BytesStart::new("graphml")))?;
-
-    // Define all valid annotation ns/name pairs
-    progress_callback("exporting all available annotation keys");
-    let key_id_mapping =
-        write_annotation_keys(graph, graph_configuration.is_some(), false, &mut writer)?;
-
-    // We are writing a single graph
-    let mut graph_start = BytesStart::new("graph");
-    graph_start.push_attribute(("edgedefault", "directed"));
-    // Add parse helper information to allow more efficient parsing
-    graph_start.push_attribute(("parse.order", "nodesfirst"));
-    graph_start.push_attribute(("parse.nodeids", "free"));
-    graph_start.push_attribute(("parse.edgeids", "canonical"));
-
-    writer.write_event(Event::Start(graph_start))?;
-
-    // If graph configuration is given, add it as data element to the graph
-    if let Some(config) = graph_configuration {
-        let mut data_start = BytesStart::new("data");
-        // This is always the first key ID
-        data_start.push_attribute(("key", "k0"));
-        writer.write_event(Event::Start(data_start))?;
-        // Add the annotation value as internal text node
-        writer.write_event(Event::CData(BytesCData::new(config)))?;
-        writer.write_event(Event::End(BytesEnd::new("data")))?;
-    }
-
-    // Write out all nodes
-    progress_callback("exporting nodes");
-    write_nodes(graph, &mut writer, false, &key_id_mapping)?;
-
-    // Write out all edges
-    progress_callback("exporting edges");
-    write_edges(graph, &mut writer, false, &key_id_mapping)?;
-
-    writer.write_event(Event::End(BytesEnd::new("graph")))?;
-    writer.write_event(Event::End(BytesEnd::new("graphml")))?;
-
-    // Make sure to flush the buffered writer
-    writer.into_inner().flush()?;
-
-    Ok(())
-}
-
-/// Export the GraphML file and ensure a stable order of the XML elements.
-///
-/// This is slower than [`export`] but can e.g. be used in tests where the
-/// output should always be the same.
-pub fn export_stable_order<CT: ComponentType, W: std::io::Write, F>(
-    graph: &Graph<CT>,
-    graph_configuration: Option<&str>,
-    output: W,
-    progress_callback: F,
-) -> Result<()>
-where
-    F: Fn(&str),
-{
-    // Always buffer the output
-    let output = BufWriter::new(output);
-    let mut writer = Writer::new_with_indent(output, b' ', 4);
-
-    // Add XML declaration
-    let xml_decl = BytesDecl::new("1.0", Some("UTF-8"), None);
-    writer.write_event(Event::Decl(xml_decl))?;
-
-    // Always write the root element
-    writer.write_event(Event::Start(BytesStart::new("graphml")))?;
-
-    // Define all valid annotation ns/name pairs
-    progress_callback("exporting all available annotation keys");
-    let key_id_mapping =
-        write_annotation_keys(graph, graph_configuration.is_some(), true, &mut writer)?;
-
-    // We are writing a single graph
-    let mut graph_start = BytesStart::new("graph");
-    graph_start.push_attribute(("edgedefault", "directed"));
-    // Add parse helper information to allow more efficient parsing
-    graph_start.push_attribute(("parse.order", "nodesfirst"));
-    graph_start.push_attribute(("parse.nodeids", "free"));
-    graph_start.push_attribute(("parse.edgeids", "canonical"));
-
-    writer.write_event(Event::Start(graph_start))?;
-
-    // If graph configuration is given, add it as data element to the graph
-    if let Some(config) = graph_configuration {
-        let mut data_start = BytesStart::new("data");
-        // This is always the first key ID
-        data_start.push_attribute(("key", "k0"));
-        writer.write_event(Event::Start(data_start))?;
-        // Add the annotation value as internal text node
-        writer.write_event(Event::CData(BytesCData::new(config)))?;
-        writer.write_event(Event::End(BytesEnd::new("data")))?;
-    }
-
-    // Write out all nodes
-    progress_callback("exporting nodes");
-    write_nodes(graph, &mut writer, true, &key_id_mapping)?;
-
-    // Write out all edges
-    progress_callback("exporting edges");
-    write_edges(graph, &mut writer, true, &key_id_mapping)?;
-
-    writer.write_event(Event::End(BytesEnd::new("graph")))?;
-    writer.write_event(Event::End(BytesEnd::new("graphml")))?;
-
-    // Make sure to flush the buffered writer
-    writer.into_inner().flush()?;
-
-    Ok(())
-}
-
 fn add_annotation_key(keys: &mut BTreeMap<String, AnnoKey>, attributes: Attributes) -> Result<()> {
     // resolve the ID to the fully qualified annotation name
     let mut id: Option<String> = None;
@@ -501,226 +729,6 @@ fn add_edge<CT: ComponentType>(
         }
     }
     Ok(())
-}
-
-/// Read in a single GraphML file from `input` and fill the updates given as
-/// parameters.
-///
-/// In order to create a [`Graph`] from it, you first have to apply the
-/// `node_updates` and then the `edge_updates`. Status updates can be retrieved
-/// by the `progress_updates` closure, that will be called with a message as
-/// argument and can be used e.g. for logging or displaying the status message
-/// to the user.
-///
-/// # Returns
-///
-/// If the GraphML-file contains a corpus configuration, this is returned as a string.
-pub fn read_graphml<CT: ComponentType, R: std::io::BufRead, F: Fn(&str)>(
-    input: &mut R,
-    node_updates: &mut GraphUpdate,
-    edge_updates: &mut GraphUpdate,
-    progress_callback: &F,
-) -> Result<Option<String>> {
-    let mut reader = Reader::from_reader(input);
-    reader.expand_empty_elements(true);
-
-    let mut keys = BTreeMap::new();
-
-    let mut level = 0;
-    let mut in_graph = false;
-    let mut current_node_id: Option<String> = None;
-    let mut current_data_key: Option<String> = None;
-    let mut current_source_id: Option<String> = None;
-    let mut current_target_id: Option<String> = None;
-    let mut current_component: Option<String> = None;
-    let mut current_data_value: Option<String> = None;
-    let mut data: HashMap<AnnoKey, String> = HashMap::new();
-
-    let mut config = None;
-
-    let mut processed_updates = 0;
-
-    let mut buf = Vec::new();
-    loop {
-        match reader.read_event_into(&mut buf)? {
-            Event::Start(ref e) => {
-                level += 1;
-
-                match e.name().0 {
-                    b"graph" if level == 2 => {
-                        in_graph = true;
-                    }
-                    b"key" if level == 2 => {
-                        add_annotation_key(&mut keys, e.attributes())?;
-                    }
-                    b"node" if in_graph && level == 3 => {
-                        data.clear();
-                        // Get the ID of this node
-                        for att in e.attributes() {
-                            let att = att?;
-                            if att.key.0 == b"id" {
-                                current_node_id =
-                                    Some(String::from_utf8_lossy(&att.value).to_string());
-                            }
-                        }
-                    }
-
-                    b"edge" if in_graph && level == 3 => {
-                        data.clear();
-                        // Get the source and target node IDs
-                        for att in e.attributes() {
-                            let att = att?;
-                            if att.key.0 == b"source" {
-                                current_source_id =
-                                    Some(String::from_utf8_lossy(&att.value).to_string());
-                            } else if att.key.0 == b"target" {
-                                current_target_id =
-                                    Some(String::from_utf8_lossy(&att.value).to_string());
-                            } else if att.key.0 == b"label" {
-                                current_component =
-                                    Some(String::from_utf8_lossy(&att.value).to_string());
-                            }
-                        }
-                    }
-
-                    b"data" => {
-                        for att in e.attributes() {
-                            let att = att?;
-                            if att.key.0 == b"key" {
-                                current_data_key =
-                                    Some(String::from_utf8_lossy(&att.value).to_string());
-                            }
-                        }
-                    }
-                    _ => {}
-                }
-            }
-            Event::Text(t) if in_graph && level == 4 && current_data_key.is_some() => {
-                current_data_value = Some(t.unescape()?.to_string());
-            }
-
-            Event::CData(t) => {
-                if let Some(current_data_key) = &current_data_key
-                    && in_graph
-                    && level == 3
-                    && current_data_key == "k0"
-                {
-                    // This is the configuration content
-                    config = Some(String::from_utf8_lossy(&t).to_string());
-                }
-            }
-            Event::End(ref e) => {
-                match e.name().0 {
-                    b"graph" => {
-                        in_graph = false;
-                    }
-                    b"node" => {
-                        add_node(node_updates, &current_node_id, &mut data)?;
-                        current_node_id = None;
-                        processed_updates += 1;
-                        if processed_updates % 1_000_000 == 0 {
-                            progress_callback(&format!(
-                                "Processed {} GraphML nodes and edges",
-                                processed_updates
-                            ));
-                        }
-                    }
-                    b"edge" => {
-                        add_edge::<CT>(
-                            edge_updates,
-                            &current_source_id,
-                            &current_target_id,
-                            &current_component,
-                            &mut data,
-                        )?;
-                        current_source_id = None;
-                        current_target_id = None;
-                        current_component = None;
-                        processed_updates += 1;
-                        if processed_updates % 1_000_000 == 0 {
-                            progress_callback(&format!(
-                                "Processed {} GraphML nodes and edges",
-                                processed_updates
-                            ));
-                        }
-                    }
-                    b"data" => {
-                        if let Some(current_data_key) = current_data_key
-                            && let Some(anno_key) = keys.get(&current_data_key)
-                        {
-                            // Copy all data attributes into our own map
-                            if let Some(v) = current_data_value.take() {
-                                data.insert(anno_key.clone(), v);
-                            } else {
-                                // If there is an end tag without any text
-                                // data event, the value exists but is
-                                // empty.
-                                data.insert(anno_key.clone(), String::default());
-                            }
-                        }
-
-                        current_data_value = None;
-                        current_data_key = None;
-                    }
-                    _ => {}
-                }
-
-                level -= 1;
-            }
-            Event::Eof => {
-                break;
-            }
-            _ => {}
-        }
-        // Clear the buffer after each event
-        buf.clear();
-    }
-    Ok(config)
-}
-
-pub fn import<CT: ComponentType, R: Read, F>(
-    input: R,
-    disk_based: bool,
-    progress_callback: F,
-) -> Result<(Graph<CT>, Option<String>)>
-where
-    F: Fn(&str),
-{
-    // Always buffer the read operations
-    let mut input = BufReader::new(input);
-    let mut g = Graph::with_default_graphstorages(disk_based)?;
-    let mut updates = GraphUpdate::default();
-    let mut edge_updates = GraphUpdate::default();
-
-    // read in all nodes and edges, collecting annotation keys on the fly
-    progress_callback("reading GraphML");
-    let config = read_graphml::<CT, BufReader<R>, F>(
-        &mut input,
-        &mut updates,
-        &mut edge_updates,
-        &progress_callback,
-    )?;
-
-    // Append all edges updates after the node updates:
-    // edges would not be added if the nodes they are referring do not exist
-    progress_callback("merging generated events");
-    for event in edge_updates.iter()? {
-        let (_, event) = event?;
-        updates.add_event(event)?;
-    }
-
-    progress_callback("applying imported changes");
-    g.apply_update(&mut updates, &progress_callback)?;
-
-    progress_callback("calculating graph statistics");
-    g.calculate_all_statistics()?;
-
-    for c in g.get_all_components(None, None) {
-        progress_callback(&format!("optimizing implementation for component {}", c));
-        g.optimize_gs_impl(&c)?;
-    }
-
-    Ok((g, config))
 }
 
 #[cfg(test)]

--- a/core/src/graph/serialization/graphml.rs
+++ b/core/src/graph/serialization/graphml.rs
@@ -952,17 +952,29 @@ value = "test""#;
 
         let result = files_for_corpus(example_corpus).unwrap();
         assert_eq!(3, result.len());
+
         assert_eq!(
-            "tests/partioned-graphml/single_sentence.graphml",
-            result[0].to_string_lossy()
+            vec!["tests", "partioned-graphml", "single_sentence.graphml"],
+            result[0].components().map(|c| c.as_os_str()).collect_vec()
         );
         assert_eq!(
-            "tests/partioned-graphml/single_sentence/zossen.graphml",
-            result[1].to_string_lossy()
+            vec![
+                "tests",
+                "partioned-graphml",
+                "single_sentence",
+                "zossen.graphml"
+            ],
+            result[1].components().map(|c| c.as_os_str()).collect_vec()
         );
         assert_eq!(
-            "tests/partioned-graphml/single_sentence/subcorpus1/anotherdocument.graphml",
-            result[2].to_string_lossy()
+            vec![
+                "tests",
+                "partioned-graphml",
+                "single_sentence",
+                "subcorpus1",
+                "anotherdocument.graphml"
+            ],
+            result[2].components().map(|c| c.as_os_str()).collect_vec()
         );
     }
 
@@ -973,6 +985,9 @@ value = "test""#;
 
         let result = files_for_corpus(example_corpus).unwrap();
         assert_eq!(1, result.len());
-        assert_eq!("tests/single_sentence.graphml", result[0].to_string_lossy());
+        assert_eq!(
+            vec!["tests", "single_sentence.graphml"],
+            result[0].components().map(|c| c.as_os_str()).collect_vec()
+        );
     }
 }

--- a/core/src/graph/serialization/graphml.rs
+++ b/core/src/graph/serialization/graphml.rs
@@ -22,7 +22,7 @@ use std::{
     str::FromStr,
 };
 
-/// Import a GraphML-file as an annotation [`Graph`].
+/// Import a single GraphML-file as an annotation [`Graph`].
 ///
 /// # Returns
 ///

--- a/core/src/graph/serialization/graphml.rs
+++ b/core/src/graph/serialization/graphml.rs
@@ -503,7 +503,19 @@ fn add_edge<CT: ComponentType>(
     Ok(())
 }
 
-fn read_graphml<CT: ComponentType, R: std::io::BufRead, F: Fn(&str)>(
+/// Read in a single GraphML file from `input` and fill the updates given as
+/// parameters.
+///
+/// In order to create a [`Graph`] from it, you first have to apply the
+/// `node_updates` and then the `edge_updates`. Status updates can be retrieved
+/// by the `progress_updates` closure, that will be called with a message as
+/// argument and can be used e.g. for logging or displaying the status message
+/// to the user.
+///
+/// # Returns
+///
+/// If the GraphML-file contains a corpus configuration, this is returned as a string.
+pub fn read_graphml<CT: ComponentType, R: std::io::BufRead, F: Fn(&str)>(
     input: &mut R,
     node_updates: &mut GraphUpdate,
     edge_updates: &mut GraphUpdate,

--- a/core/tests/partioned-graphml/single_sentence.graphml
+++ b/core/tests/partioned-graphml/single_sentence.graphml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<graphml>
+    <key id="k0" for="graph" attr.name="configuration" attr.type="string"/>
+    <key id="k1" for="node" attr.name="syntax::cat" attr.type="string"/>
+    <key id="k2" for="node" attr.name="annis::doc" attr.type="string"/>
+    <key id="k3" for="node" attr.name="annis::layer" attr.type="string"/>
+    <key id="k4" for="node" attr.name="annis::node_type" attr.type="string"/>
+    <key id="k5" for="node" attr.name="default_ns::visible_description" attr.type="string"/>
+    <graph edgedefault="directed" parse.order="nodesfirst" parse.nodeids="free" parse.edgeids="canonical">
+        <data key="k0"><![CDATA[
+# configure visualizations here
+]]></data>
+        <node id="single_sentence">
+            <data key="k4">corpus</data>
+            <data key="k5">This is root corpus.</data>
+        </node>
+        <node id="single_sentence/zossen">
+            <data key="k2">zossen</data>
+            <data key="k4">corpus</data>
+        </node>
+        <node id="single_sentence/subcorpus1">
+            <data key="k4">corpus</data>
+            <data key="k5">This is subcorpus.</data>
+        </node>
+        <node id="single_sentence/subcorpus1/anotherdocument">
+            <data key="k2">anotherdocument</data>
+            <data key="k4">corpus</data>
+        </node>
+        <node id="single_sentence/zossen#n1">
+            <data key="k1">ROOT</data>
+            <data key="k3">syntax</data>
+            <data key="k4">node</data>
+        </node>
+        <node id="single_sentence/zossen#n2">
+            <data key="k1">S</data>
+            <data key="k3">syntax</data>
+            <data key="k4">node</data>
+        </node>
+        <node id="single_sentence/zossen#n3">
+            <data key="k1">NP</data>
+            <data key="k3">syntax</data>
+            <data key="k4">node</data>
+        </node>
+        <node id="single_sentence/zossen#n4">
+            <data key="k1">PP</data>
+            <data key="k3">syntax</data>
+            <data key="k4">node</data>
+        </node>
+        <node id="single_sentence/zossen#n5">
+            <data key="k1">NP</data>
+            <data key="k3">syntax</data>
+            <data key="k4">node</data>
+        </node>
+        <edge id="e0" source="single_sentence/zossen#n1" target="single_sentence/zossen#n2" label="Dominance/syntax/">
+        </edge>
+        <edge id="e1" source="single_sentence/zossen#n2" target="single_sentence/zossen#n3" label="Dominance/syntax/">
+        </edge>
+        <edge id="e2" source="single_sentence/zossen#n2" target="single_sentence/zossen#n5" label="Dominance/syntax/">
+        </edge>
+        <edge id="e3" source="single_sentence/zossen#n3" target="single_sentence/zossen#n4" label="Dominance/syntax/">
+        </edge>
+        <edge id="e4" source="single_sentence/zossen#n1" target="single_sentence/zossen#n2" label="Dominance/syntax/edge">
+        </edge>
+        <edge id="e5" source="single_sentence/zossen#n2" target="single_sentence/zossen#n3" label="Dominance/syntax/edge">
+        </edge>
+        <edge id="e6" source="single_sentence/zossen#n2" target="single_sentence/zossen#n5" label="Dominance/syntax/edge">
+        </edge>
+        <edge id="e7" source="single_sentence/zossen#n3" target="single_sentence/zossen#n4" label="Dominance/syntax/edge">
+        </edge>
+        <edge id="e8" source="single_sentence/zossen" target="single_sentence" label="PartOf/annis/">
+        </edge>
+        <edge id="e9" source="single_sentence/subcorpus1" target="single_sentence" label="PartOf/annis/">
+        </edge>
+        <edge id="e10" source="single_sentence/subcorpus1/anotherdocument" target="single_sentence/subcorpus1" label="PartOf/annis/">
+        </edge>
+    </graph>
+</graphml>

--- a/core/tests/partioned-graphml/single_sentence/subcorpus1/anotherdocument.graphml
+++ b/core/tests/partioned-graphml/single_sentence/subcorpus1/anotherdocument.graphml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<graphml>
+    <key id="k0" for="node" attr.name="annis::doc" attr.type="string"/>
+    <key id="k1" for="node" attr.name="annis::node_type" attr.type="string"/>
+    <key id="k2" for="node" attr.name="default_ns::visible_description" attr.type="string"/>
+    <graph edgedefault="directed" parse.order="nodesfirst" parse.nodeids="free" parse.edgeids="canonical">
+        <node id="single_sentence/subcorpus1/anotherdocument">
+            <data key="k0">anotherdocument</data>
+            <data key="k1">corpus</data>
+            <data key="k2">This is a document without content.</data>
+        </node>
+    </graph>
+</graphml>

--- a/core/tests/partioned-graphml/single_sentence/zossen.graphml
+++ b/core/tests/partioned-graphml/single_sentence/zossen.graphml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<graphml>
+    <key id="k0" for="node" attr.name="annis::doc" attr.type="string"/>
+    <key id="k1" for="node" attr.name="annis::layer" attr.type="string"/>
+    <key id="k2" for="node" attr.name="annis::node_type" attr.type="string"/>
+    <key id="k3" for="node" attr.name="default_ns::pos" attr.type="string"/>
+    <key id="k4" for="node" attr.name="annis::tok" attr.type="string"/>
+    <key id="k5" for="node" attr.name="annis::tok-whitespace-before" attr.type="string"/>
+    <key id="k6" for="node" attr.name="default_ns::visible_description" attr.type="string"/>
+    <graph edgedefault="directed" parse.order="nodesfirst" parse.nodeids="free" parse.edgeids="canonical">
+        <node id="single_sentence/zossen">
+            <data key="k0">zossen</data>
+            <data key="k2">corpus</data>
+            <data key="k6">This is a document with actual content.</data>
+        </node>
+        <node id="single_sentence/zossen#text">
+            <data key="k2">datasource</data>
+        </node>
+        <node id="single_sentence/zossen#t1">
+            <data key="k1">default_layer</data>
+            <data key="k2">node</data>
+            <data key="k3">ART</data>
+            <data key="k4">Die</data>
+        </node>
+        <node id="single_sentence/zossen#t2">
+            <data key="k1">default_layer</data>
+            <data key="k2">node</data>
+            <data key="k3">NN</data>
+            <data key="k4">Jugendlichen</data>
+            <data key="k5"> </data>
+        </node>
+        <node id="single_sentence/zossen#t3">
+            <data key="k1">default_layer</data>
+            <data key="k2">node</data>
+            <data key="k3">APPR</data>
+            <data key="k4">in</data>
+            <data key="k5"> </data>
+        </node>
+        <node id="single_sentence/zossen#t4">
+            <data key="k1">default_layer</data>
+            <data key="k2">node</data>
+            <data key="k3">NE</data>
+            <data key="k4">Zossen</data>
+            <data key="k5"> </data>
+        </node>
+        <node id="single_sentence/zossen#t5">
+            <data key="k1">default_layer</data>
+            <data key="k2">node</data>
+            <data key="k3">VMFIN</data>
+            <data key="k4">wollen</data>
+            <data key="k5"> </data>
+        </node>
+        <node id="single_sentence/zossen#t6">
+            <data key="k1">default_layer</data>
+            <data key="k2">node</data>
+            <data key="k3">ART</data>
+            <data key="k4">ein</data>
+            <data key="k5"> </data>
+        </node>
+        <node id="single_sentence/zossen#t7">
+            <data key="k1">default_layer</data>
+            <data key="k2">node</data>
+            <data key="k3">NN</data>
+            <data key="k4">Musikcafé</data>
+            <data key="k5"> </data>
+        </node>
+        <node id="single_sentence/zossen#t8">
+            <data key="k1">default_layer</data>
+            <data key="k2">node</data>
+            <data key="k3">$.</data>
+            <data key="k4">.</data>
+            <data key="k5"> </data>
+        </node>
+        <edge id="e0" source="single_sentence/zossen#t1" target="single_sentence/zossen#t2" label="Ordering/annis/">
+        </edge>
+        <edge id="e1" source="single_sentence/zossen#t2" target="single_sentence/zossen#t3" label="Ordering/annis/">
+        </edge>
+        <edge id="e2" source="single_sentence/zossen#t3" target="single_sentence/zossen#t4" label="Ordering/annis/">
+        </edge>
+        <edge id="e3" source="single_sentence/zossen#t4" target="single_sentence/zossen#t5" label="Ordering/annis/">
+        </edge>
+        <edge id="e4" source="single_sentence/zossen#t5" target="single_sentence/zossen#t6" label="Ordering/annis/">
+        </edge>
+        <edge id="e5" source="single_sentence/zossen#t6" target="single_sentence/zossen#t7" label="Ordering/annis/">
+        </edge>
+        <edge id="e6" source="single_sentence/zossen#t7" target="single_sentence/zossen#t8" label="Ordering/annis/">
+        </edge>
+        <edge id="e7" source="single_sentence/zossen#text" target="single_sentence/zossen" label="PartOf/annis/">
+        </edge>
+        <edge id="e8" source="single_sentence/zossen#t1" target="single_sentence/zossen#text" label="PartOf/annis/">
+        </edge>
+        <edge id="e9" source="single_sentence/zossen#t2" target="single_sentence/zossen#text" label="PartOf/annis/">
+        </edge>
+        <edge id="e10" source="single_sentence/zossen#t3" target="single_sentence/zossen#text" label="PartOf/annis/">
+        </edge>
+        <edge id="e11" source="single_sentence/zossen#t4" target="single_sentence/zossen#text" label="PartOf/annis/">
+        </edge>
+        <edge id="e12" source="single_sentence/zossen#t5" target="single_sentence/zossen#text" label="PartOf/annis/">
+        </edge>
+        <edge id="e13" source="single_sentence/zossen#t6" target="single_sentence/zossen#text" label="PartOf/annis/">
+        </edge>
+        <edge id="e14" source="single_sentence/zossen#t7" target="single_sentence/zossen#text" label="PartOf/annis/">
+        </edge>
+        <edge id="e15" source="single_sentence/zossen#t8" target="single_sentence/zossen#text" label="PartOf/annis/">
+        </edge>
+    </graph>
+</graphml>

--- a/core/tests/single_sentence.graphml
+++ b/core/tests/single_sentence.graphml
@@ -1,0 +1,241 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<graphml>
+    <key id="k0" for="node" attr.name="syntax::cat" attr.type="string" />
+    <key id="k1" for="node" attr.name="annis::doc" attr.type="string" />
+    <key id="k2" for="node" attr.name="annis::layer" attr.type="string" />
+    <key id="k3" for="node" attr.name="annis::node_type" attr.type="string" />
+    <key id="k4" for="node" attr.name="default_ns::pos" attr.type="string" />
+    <key id="k5" for="node" attr.name="annis::tok" attr.type="string" />
+    <key id="k6" for="node" attr.name="annis::tok-whitespace-before" attr.type="string" />
+    <graph edgedefault="directed" parse.order="nodesfirst" parse.nodeids="free"
+        parse.edgeids="canonical">
+        <node id="single_sentence">
+            <data key="k3">corpus</data>
+        </node>
+        <node id="single_sentence/zossen">
+            <data key="k1">zossen</data>
+            <data key="k3">corpus</data>
+        </node>
+        <node id="single_sentence/zossen#text">
+            <data key="k3">datasource</data>
+        </node>
+        <node id="single_sentence/zossen#n1">
+            <data key="k0">ROOT</data>
+            <data key="k2">syntax</data>
+            <data key="k3">node</data>
+        </node>
+        <node id="single_sentence/zossen#n2">
+            <data key="k0">S</data>
+            <data key="k2">syntax</data>
+            <data key="k3">node</data>
+        </node>
+        <node id="single_sentence/zossen#n3">
+            <data key="k0">NP</data>
+            <data key="k2">syntax</data>
+            <data key="k3">node</data>
+        </node>
+        <node id="single_sentence/zossen#t1">
+            <data key="k2">default_layer</data>
+            <data key="k3">node</data>
+            <data key="k4">ART</data>
+            <data key="k5">Die</data>
+        </node>
+        <node id="single_sentence/zossen#t2">
+            <data key="k2">default_layer</data>
+            <data key="k3">node</data>
+            <data key="k4">NN</data>
+            <data key="k5">Jugendlichen</data>
+            <data key="k6"> </data>
+        </node>
+        <node id="single_sentence/zossen#n4">
+            <data key="k0">PP</data>
+            <data key="k2">syntax</data>
+            <data key="k3">node</data>
+        </node>
+        <node id="single_sentence/zossen#t3">
+            <data key="k2">default_layer</data>
+            <data key="k3">node</data>
+            <data key="k4">APPR</data>
+            <data key="k5">in</data>
+            <data key="k6"> </data>
+        </node>
+        <node id="single_sentence/zossen#t4">
+            <data key="k2">default_layer</data>
+            <data key="k3">node</data>
+            <data key="k4">NE</data>
+            <data key="k5">Zossen</data>
+            <data key="k6"> </data>
+        </node>
+        <node id="single_sentence/zossen#t5">
+            <data key="k2">default_layer</data>
+            <data key="k3">node</data>
+            <data key="k4">VMFIN</data>
+            <data key="k5">wollen</data>
+            <data key="k6"> </data>
+        </node>
+        <node id="single_sentence/zossen#n5">
+            <data key="k0">NP</data>
+            <data key="k2">syntax</data>
+            <data key="k3">node</data>
+        </node>
+        <node id="single_sentence/zossen#t6">
+            <data key="k2">default_layer</data>
+            <data key="k3">node</data>
+            <data key="k4">ART</data>
+            <data key="k5">ein</data>
+            <data key="k6"> </data>
+        </node>
+        <node id="single_sentence/zossen#t7">
+            <data key="k2">default_layer</data>
+            <data key="k3">node</data>
+            <data key="k4">NN</data>
+            <data key="k5">Musikcafé</data>
+            <data key="k6"> </data>
+        </node>
+        <node id="single_sentence/zossen#t8">
+            <data key="k2">default_layer</data>
+            <data key="k3">node</data>
+            <data key="k4">$.</data>
+            <data key="k5">.</data>
+            <data key="k6"> </data>
+        </node>
+        <edge id="e0" source="single_sentence/zossen#n1" target="single_sentence/zossen#n2"
+            label="Dominance/syntax/">
+        </edge>
+        <edge id="e1" source="single_sentence/zossen#n1" target="single_sentence/zossen#t8"
+            label="Dominance/syntax/">
+        </edge>
+        <edge id="e2" source="single_sentence/zossen#n2" target="single_sentence/zossen#n3"
+            label="Dominance/syntax/">
+        </edge>
+        <edge id="e3" source="single_sentence/zossen#n2" target="single_sentence/zossen#t5"
+            label="Dominance/syntax/">
+        </edge>
+        <edge id="e4" source="single_sentence/zossen#n2" target="single_sentence/zossen#n5"
+            label="Dominance/syntax/">
+        </edge>
+        <edge id="e5" source="single_sentence/zossen#n3" target="single_sentence/zossen#t1"
+            label="Dominance/syntax/">
+        </edge>
+        <edge id="e6" source="single_sentence/zossen#n3" target="single_sentence/zossen#t2"
+            label="Dominance/syntax/">
+        </edge>
+        <edge id="e7" source="single_sentence/zossen#n3" target="single_sentence/zossen#n4"
+            label="Dominance/syntax/">
+        </edge>
+        <edge id="e8" source="single_sentence/zossen#n4" target="single_sentence/zossen#t3"
+            label="Dominance/syntax/">
+        </edge>
+        <edge id="e9" source="single_sentence/zossen#n4" target="single_sentence/zossen#t4"
+            label="Dominance/syntax/">
+        </edge>
+        <edge id="e10" source="single_sentence/zossen#n5" target="single_sentence/zossen#t6"
+            label="Dominance/syntax/">
+        </edge>
+        <edge id="e11" source="single_sentence/zossen#n5" target="single_sentence/zossen#t7"
+            label="Dominance/syntax/">
+        </edge>
+        <edge id="e12" source="single_sentence/zossen#n1" target="single_sentence/zossen#n2"
+            label="Dominance/syntax/edge">
+        </edge>
+        <edge id="e13" source="single_sentence/zossen#n1" target="single_sentence/zossen#t8"
+            label="Dominance/syntax/edge">
+        </edge>
+        <edge id="e14" source="single_sentence/zossen#n2" target="single_sentence/zossen#n3"
+            label="Dominance/syntax/edge">
+        </edge>
+        <edge id="e15" source="single_sentence/zossen#n2" target="single_sentence/zossen#t5"
+            label="Dominance/syntax/edge">
+        </edge>
+        <edge id="e16" source="single_sentence/zossen#n2" target="single_sentence/zossen#n5"
+            label="Dominance/syntax/edge">
+        </edge>
+        <edge id="e17" source="single_sentence/zossen#n3" target="single_sentence/zossen#t1"
+            label="Dominance/syntax/edge">
+        </edge>
+        <edge id="e18" source="single_sentence/zossen#n3" target="single_sentence/zossen#t2"
+            label="Dominance/syntax/edge">
+        </edge>
+        <edge id="e19" source="single_sentence/zossen#n3" target="single_sentence/zossen#n4"
+            label="Dominance/syntax/edge">
+        </edge>
+        <edge id="e20" source="single_sentence/zossen#n4" target="single_sentence/zossen#t3"
+            label="Dominance/syntax/edge">
+        </edge>
+        <edge id="e21" source="single_sentence/zossen#n4" target="single_sentence/zossen#t4"
+            label="Dominance/syntax/edge">
+        </edge>
+        <edge id="e22" source="single_sentence/zossen#n5" target="single_sentence/zossen#t6"
+            label="Dominance/syntax/edge">
+        </edge>
+        <edge id="e23" source="single_sentence/zossen#n5" target="single_sentence/zossen#t7"
+            label="Dominance/syntax/edge">
+        </edge>
+        <edge id="e24" source="single_sentence/zossen#t1" target="single_sentence/zossen#t2"
+            label="Ordering/annis/">
+        </edge>
+        <edge id="e25" source="single_sentence/zossen#t2" target="single_sentence/zossen#t3"
+            label="Ordering/annis/">
+        </edge>
+        <edge id="e26" source="single_sentence/zossen#t3" target="single_sentence/zossen#t4"
+            label="Ordering/annis/">
+        </edge>
+        <edge id="e27" source="single_sentence/zossen#t4" target="single_sentence/zossen#t5"
+            label="Ordering/annis/">
+        </edge>
+        <edge id="e28" source="single_sentence/zossen#t5" target="single_sentence/zossen#t6"
+            label="Ordering/annis/">
+        </edge>
+        <edge id="e29" source="single_sentence/zossen#t6" target="single_sentence/zossen#t7"
+            label="Ordering/annis/">
+        </edge>
+        <edge id="e30" source="single_sentence/zossen#t7" target="single_sentence/zossen#t8"
+            label="Ordering/annis/">
+        </edge>
+        <edge id="e31" source="single_sentence/zossen" target="single_sentence"
+            label="PartOf/annis/">
+        </edge>
+        <edge id="e32" source="single_sentence/zossen#text" target="single_sentence/zossen"
+            label="PartOf/annis/">
+        </edge>
+        <edge id="e33" source="single_sentence/zossen#t1" target="single_sentence/zossen#text"
+            label="PartOf/annis/">
+        </edge>
+        <edge id="e34" source="single_sentence/zossen#t2" target="single_sentence/zossen#text"
+            label="PartOf/annis/">
+        </edge>
+        <edge id="e35" source="single_sentence/zossen#t3" target="single_sentence/zossen#text"
+            label="PartOf/annis/">
+        </edge>
+        <edge id="e36" source="single_sentence/zossen#t4" target="single_sentence/zossen#text"
+            label="PartOf/annis/">
+        </edge>
+        <edge id="e37" source="single_sentence/zossen#t5" target="single_sentence/zossen#text"
+            label="PartOf/annis/">
+        </edge>
+        <edge id="e38" source="single_sentence/zossen#t6" target="single_sentence/zossen#text"
+            label="PartOf/annis/">
+        </edge>
+        <edge id="e39" source="single_sentence/zossen#t7" target="single_sentence/zossen#text"
+            label="PartOf/annis/">
+        </edge>
+        <edge id="e40" source="single_sentence/zossen#t8" target="single_sentence/zossen#text"
+            label="PartOf/annis/">
+        </edge>
+        <edge id="e41" source="single_sentence/zossen#n1" target="single_sentence/zossen#text"
+            label="PartOf/annis/">
+        </edge>
+        <edge id="e42" source="single_sentence/zossen#n2" target="single_sentence/zossen#text"
+            label="PartOf/annis/">
+        </edge>
+        <edge id="e43" source="single_sentence/zossen#n3" target="single_sentence/zossen#text"
+            label="PartOf/annis/">
+        </edge>
+        <edge id="e44" source="single_sentence/zossen#n4" target="single_sentence/zossen#text"
+            label="PartOf/annis/">
+        </edge>
+        <edge id="e45" source="single_sentence/zossen#n5" target="single_sentence/zossen#text"
+            label="PartOf/annis/">
+        </edge>
+    </graph>
+</graphml>

--- a/graphannis/src/annis/db/aql/mod.rs
+++ b/graphannis/src/annis/db/aql/mod.rs
@@ -264,7 +264,7 @@ fn map_conjunction(
         // Add additional nodes to the query to emulate the old behavior of distributing
         // joins for pointing and dominance operators on different query nodes.
         // Iterate over the query nodes in their order as given by the query.
-        for (_, orig_var) in pos_to_node_id.iter() {
+        for orig_var in pos_to_node_id.values() {
             let num_joins = num_pointing_or_dominance_joins.get(orig_var).unwrap_or(&0);
             // add an additional node for each extra join and join this artificial node with identity relation
             for _ in 1..*num_joins {

--- a/graphannis/src/annis/db/aql/operators/edge_op.rs
+++ b/graphannis/src/annis/db/aql/operators/edge_op.rs
@@ -40,7 +40,7 @@ impl BaseEdgeOp {
         let mut gs: Vec<Arc<dyn GraphStorage>> = Vec::new();
         for c in &spec.components {
             let gs_for_component = db.get_graphstorage(c).ok_or_else(|| {
-                GraphAnnisError::ImpossibleSearch(format!("Component {} does not exist", &c))
+                GraphAnnisError::ImpossibleSearch(format!("Component {} does not exist", c))
             })?;
 
             gs.push(gs_for_component);
@@ -641,7 +641,7 @@ impl BinaryOperatorSpec for DominanceSpec {
         let op_str = if self.name.is_empty() {
             String::from(">")
         } else {
-            format!(">{} ", &self.name)
+            format!(">{} ", self.name)
         };
         let base = BaseEdgeOpSpec {
             op_str: Some(op_str),

--- a/graphannis/src/annis/db/corpusstorage.rs
+++ b/graphannis/src/annis/db/corpusstorage.rs
@@ -951,17 +951,45 @@ impl CorpusStorage {
                     "UnknownCorpus".to_string()
                 };
                 let input_file = File::open(path)?;
-                let (g, config_str) = graphannis_core::graph::serialization::graphml::import(
-                    input_file,
-                    disk_based,
-                    |status| {
-                        progress_callback(status);
-                        // loading the file from GraphmL consumes memory, update the corpus cache regularly to allow it to adapt
-                        if let Err(e) = self.check_cache_size_and_remove(vec![]) {
-                            error!("Could not check cache size: {}", e);
-                        };
-                    },
+
+                // Always buffer the read operations
+                let mut input = BufReader::new(input_file);
+                let mut g = AnnotationGraph::with_default_graphstorages(disk_based)?;
+                let mut updates = GraphUpdate::default();
+                let mut edge_updates = GraphUpdate::default();
+
+                // read in all nodes and edges, collecting annotation keys on the fly
+                progress_callback("reading GraphML");
+                let config_str = graphannis_core::graph::serialization::graphml::read_graphml::<
+                    AnnotationComponentType,
+                    _,
+                    _,
+                >(
+                    &mut input,
+                    &mut updates,
+                    &mut edge_updates,
+                    &progress_callback,
                 )?;
+
+                // Append all edges updates after the node updates:
+                // edges would not be added if the nodes they are referring do not exist
+                progress_callback("merging generated events");
+                for event in edge_updates.iter()? {
+                    let (_, event) = event?;
+                    updates.add_event(event)?;
+                }
+
+                progress_callback("applying imported changes");
+                g.apply_update(&mut updates, &progress_callback)?;
+
+                progress_callback("calculating graph statistics");
+                g.calculate_all_statistics()?;
+
+                for c in g.get_all_components(None, None) {
+                    progress_callback(&format!("optimizing implementation for component {}", c));
+                    g.optimize_gs_impl(&c)?;
+                }
+
                 let config = if let Some(config_str) = config_str {
                     toml::from_str(&config_str)?
                 } else {

--- a/graphannis/src/annis/db/corpusstorage.rs
+++ b/graphannis/src/annis/db/corpusstorage.rs
@@ -18,6 +18,7 @@ use crate::annis::types::{CorpusSizeInfo, CountExtra};
 use crate::annis::util::TimeoutCheck;
 use crate::annis::util::quicksort;
 use crate::{AnnotationGraph, graph::Match};
+use facet::Facet;
 use fmt::Display;
 use fs2::FileExt;
 use graphannis_core::annostorage::symboltable::SymbolTable;
@@ -38,7 +39,6 @@ use memory_stats::memory_stats;
 use percent_encoding::{AsciiSet, CONTROLS, percent_decode_str, utf8_percent_encode};
 use rand::prelude::*;
 use std::collections::HashSet;
-use std::fmt;
 use std::fs::File;
 use std::fs::OpenOptions;
 use std::io::prelude::*;
@@ -48,6 +48,7 @@ use std::str::FromStr;
 use std::sync::{Arc, Condvar, Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::thread;
 use std::{borrow::Cow, time::Duration};
+use std::{default, fmt};
 use transient_btree_index::{BtreeConfig, BtreeIndex};
 
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -242,21 +243,72 @@ pub enum ImportFormat {
     /// Legacy [relANNIS import file format](http://korpling.github.io/ANNIS/4.0/developer-guide/annisimportformat.html)
     RelANNIS,
     /// [GraphML](http://graphml.graphdrawing.org/) based export-format, suitable to be imported from other graph databases.
-    /// This format follows the extensions/conventions of the Neo4j [GraphML module](https://neo4j.com/docs/labs/apoc/current/import/graphml/).
+    /// This format follows the extensions/conventions of the Neo4j [GraphML module](https://neo4j.com/labs/apoc/4.3/import/graphml/).
     GraphML,
 }
 
 /// An enum of all supported output formats of graphANNIS.
 #[repr(C)]
 #[derive(Clone, Copy)]
+#[deprecated(note = "Use [`ExportFormatOptions`] instead", since = "4.2.0")]
 pub enum ExportFormat {
     /// [GraphML](http://graphml.graphdrawing.org/) based export-format, suitable to be imported into other graph databases.
-    /// This format follows the extensions/conventions of the Neo4j [GraphML module](https://neo4j.com/docs/labs/apoc/current/import/graphml/).
+    /// This format follows the extensions/conventions of the Neo4j [GraphML module](https://neo4j.com/labs/apoc/4.3/import/graphml/).
     GraphML,
     /// Like `GraphML`, but compressed as ZIP file. Linked files are also copied into the ZIP file.
     GraphMLZip,
     /// Like `GraphML`, but using a directory with multiple GraphML files, each for one corpus.
     GraphMLDirectory,
+}
+
+#[allow(deprecated)]
+impl Into<ExportFormatOptions> for ExportFormat {
+    fn into(self) -> ExportFormatOptions {
+        match self {
+            ExportFormat::GraphML => ExportFormatOptions::GraphML {
+                zip: false,
+                partition_by: ExportPartition::None,
+            },
+            ExportFormat::GraphMLZip => ExportFormatOptions::GraphML {
+                zip: true,
+                partition_by: ExportPartition::None,
+            },
+            ExportFormat::GraphMLDirectory => ExportFormatOptions::GraphML {
+                zip: false,
+                partition_by: ExportPartition::RootCorpus,
+            },
+        }
+    }
+}
+
+/// GraphML exports can be partitioned. This enum defines which type of partition is applied.
+#[non_exhaustive]
+#[derive(Facet, Serialize, Deserialize, Default)]
+#[repr(u16)]
+pub enum ExportPartition {
+    /// No partition. This implies there is only one root corpus, which is
+    /// exported to a single GraphML-file.
+    None,
+    /// Each root corpus is a single GraphML file.
+    #[default]
+    RootCorpus,
+    /// Partition by a custom label. E.g. by using "annis::doc", each document will be exported to a single file.
+    Label(AnnoKey),
+}
+
+#[derive(Facet, Serialize, Deserialize)]
+#[non_exhaustive]
+#[repr(u16)]
+pub enum ExportFormatOptions {
+    /// [GraphML](http://graphml.graphdrawing.org/) based export-format, suitable to be imported into other graph databases.
+    /// This format follows the extensions/conventions of the Neo4j [GraphML module](https://neo4j.com/labs/apoc/4.3/import/graphml/).
+    ///
+    /// It can be configured for different variants, e.g. how to partition the corpus or whether to ZIP the output or not.
+    GraphML {
+        /// If true, the output files are grouped together in an compressed ZIP-file.
+        zip: bool,
+        partition_by: ExportPartition,
+    },
 }
 
 /// Different strategies how it is decided when corpora need to be removed from the cache.
@@ -1305,53 +1357,64 @@ impl CorpusStorage {
     /// - `corpora` - The corpora to include in the exported file(s).
     /// - `path` - The location on the file system where the corpus data should be written to.
     /// - `format` - The format in which this corpus data will be stored stored.
-    pub fn export_to_fs<S: AsRef<str>>(
+    pub fn export_to_fs<S: AsRef<str>, F: Into<ExportFormatOptions>>(
         &self,
         corpora: &[S],
         path: &Path,
-        format: ExportFormat,
+        format: F,
     ) -> Result<()> {
-        match format {
-            ExportFormat::GraphML => {
-                if corpora.len() == 1 {
-                    self.export_corpus_graphml(corpora[0].as_ref(), path)?;
+        let format_options: ExportFormatOptions = format.into();
+
+        match format_options {
+            ExportFormatOptions::GraphML { zip, .. } => {
+                // If we get a graphml file as path, assume we shall export to a single file, otherwise a directory
+                if let Some(ext) = path.extension()
+                    && ext == "graphml"
+                    && zip == false
+                {
+                    if corpora.len() == 1 {
+                        self.export_corpus_graphml(corpora[0].as_ref(), path)?;
+                    } else {
+                        return Err(CorpusStorageError::MultipleCorporaForSingleCorpusFormat(
+                            corpora.len(),
+                        )
+                        .into());
+                    }
+                } else if zip {
+                    let output_file = File::create(path)?;
+                    let mut zip = zip::ZipWriter::new(output_file);
+
+                    let use_corpus_subdirectory = corpora.len() > 1;
+                    for corpus_name in corpora {
+                        // Add the GraphML file to the ZIP file
+                        let corpus_name: &str = corpus_name.as_ref();
+                        self.export_to_zip(
+                            corpus_name,
+                            use_corpus_subdirectory,
+                            &mut zip,
+                            |status| {
+                                info!("{}", status);
+                            },
+                        )?;
+                    }
+
+                    zip.finish()?;
                 } else {
-                    return Err(CorpusStorageError::MultipleCorporaForSingleCorpusFormat(
-                        corpora.len(),
-                    )
-                    .into());
+                    let use_corpus_subdirectory = corpora.len() > 1;
+                    for corpus_name in corpora {
+                        let mut path = PathBuf::from(path);
+                        if use_corpus_subdirectory {
+                            // Use a sub-directory with the corpus name to avoid conflicts with the
+                            // linked files
+                            path.push(corpus_name.as_ref());
+                        };
+                        std::fs::create_dir_all(&path)?;
+                        path.push(format!("{}.graphml", corpus_name.as_ref()));
+                        self.export_corpus_graphml(corpus_name.as_ref(), &path)?;
+                    }
                 }
             }
-            ExportFormat::GraphMLDirectory => {
-                let use_corpus_subdirectory = corpora.len() > 1;
-                for corpus_name in corpora {
-                    let mut path = PathBuf::from(path);
-                    if use_corpus_subdirectory {
-                        // Use a sub-directory with the corpus name to avoid conflicts with the
-                        // linked files
-                        path.push(corpus_name.as_ref());
-                    };
-                    std::fs::create_dir_all(&path)?;
-                    path.push(format!("{}.graphml", corpus_name.as_ref()));
-                    self.export_corpus_graphml(corpus_name.as_ref(), &path)?;
-                }
-            }
-            ExportFormat::GraphMLZip => {
-                let output_file = File::create(path)?;
-                let mut zip = zip::ZipWriter::new(output_file);
-
-                let use_corpus_subdirectory = corpora.len() > 1;
-                for corpus_name in corpora {
-                    // Add the GraphML file to the ZIP file
-                    let corpus_name: &str = corpus_name.as_ref();
-                    self.export_to_zip(corpus_name, use_corpus_subdirectory, &mut zip, |status| {
-                        info!("{}", status);
-                    })?;
-                }
-
-                zip.finish()?;
-            }
-        }
+        };
 
         Ok(())
     }

--- a/graphannis/src/annis/db/corpusstorage.rs
+++ b/graphannis/src/annis/db/corpusstorage.rs
@@ -18,7 +18,6 @@ use crate::annis::types::{CorpusSizeInfo, CountExtra};
 use crate::annis::util::TimeoutCheck;
 use crate::annis::util::quicksort;
 use crate::{AnnotationGraph, graph::Match};
-use facet::Facet;
 use fmt::Display;
 use fs2::FileExt;
 use graphannis_core::annostorage::symboltable::SymbolTable;
@@ -39,6 +38,7 @@ use memory_stats::memory_stats;
 use percent_encoding::{AsciiSet, CONTROLS, percent_decode_str, utf8_percent_encode};
 use rand::prelude::*;
 use std::collections::HashSet;
+use std::fmt;
 use std::fs::File;
 use std::fs::OpenOptions;
 use std::io::prelude::*;
@@ -48,7 +48,6 @@ use std::str::FromStr;
 use std::sync::{Arc, Condvar, Mutex, RwLock, RwLockReadGuard, RwLockWriteGuard};
 use std::thread;
 use std::{borrow::Cow, time::Duration};
-use std::{default, fmt};
 use transient_btree_index::{BtreeConfig, BtreeIndex};
 
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -243,72 +242,21 @@ pub enum ImportFormat {
     /// Legacy [relANNIS import file format](http://korpling.github.io/ANNIS/4.0/developer-guide/annisimportformat.html)
     RelANNIS,
     /// [GraphML](http://graphml.graphdrawing.org/) based export-format, suitable to be imported from other graph databases.
-    /// This format follows the extensions/conventions of the Neo4j [GraphML module](https://neo4j.com/labs/apoc/4.3/import/graphml/).
+    /// This format follows the extensions/conventions of the Neo4j [GraphML module](https://neo4j.com/docs/labs/apoc/current/import/graphml/).
     GraphML,
 }
 
 /// An enum of all supported output formats of graphANNIS.
 #[repr(C)]
 #[derive(Clone, Copy)]
-#[deprecated(note = "Use [`ExportFormatOptions`] instead", since = "4.2.0")]
 pub enum ExportFormat {
     /// [GraphML](http://graphml.graphdrawing.org/) based export-format, suitable to be imported into other graph databases.
-    /// This format follows the extensions/conventions of the Neo4j [GraphML module](https://neo4j.com/labs/apoc/4.3/import/graphml/).
+    /// This format follows the extensions/conventions of the Neo4j [GraphML module](https://neo4j.com/docs/labs/apoc/current/import/graphml/).
     GraphML,
     /// Like `GraphML`, but compressed as ZIP file. Linked files are also copied into the ZIP file.
     GraphMLZip,
     /// Like `GraphML`, but using a directory with multiple GraphML files, each for one corpus.
     GraphMLDirectory,
-}
-
-#[allow(deprecated)]
-impl Into<ExportFormatOptions> for ExportFormat {
-    fn into(self) -> ExportFormatOptions {
-        match self {
-            ExportFormat::GraphML => ExportFormatOptions::GraphML {
-                zip: false,
-                partition_by: ExportPartition::None,
-            },
-            ExportFormat::GraphMLZip => ExportFormatOptions::GraphML {
-                zip: true,
-                partition_by: ExportPartition::None,
-            },
-            ExportFormat::GraphMLDirectory => ExportFormatOptions::GraphML {
-                zip: false,
-                partition_by: ExportPartition::RootCorpus,
-            },
-        }
-    }
-}
-
-/// GraphML exports can be partitioned. This enum defines which type of partition is applied.
-#[non_exhaustive]
-#[derive(Facet, Serialize, Deserialize, Default)]
-#[repr(u16)]
-pub enum ExportPartition {
-    /// No partition. This implies there is only one root corpus, which is
-    /// exported to a single GraphML-file.
-    None,
-    /// Each root corpus is a single GraphML file.
-    #[default]
-    RootCorpus,
-    /// Partition by a custom label. E.g. by using "annis::doc", each document will be exported to a single file.
-    Label(AnnoKey),
-}
-
-#[derive(Facet, Serialize, Deserialize)]
-#[non_exhaustive]
-#[repr(u16)]
-pub enum ExportFormatOptions {
-    /// [GraphML](http://graphml.graphdrawing.org/) based export-format, suitable to be imported into other graph databases.
-    /// This format follows the extensions/conventions of the Neo4j [GraphML module](https://neo4j.com/labs/apoc/4.3/import/graphml/).
-    ///
-    /// It can be configured for different variants, e.g. how to partition the corpus or whether to ZIP the output or not.
-    GraphML {
-        /// If true, the output files are grouped together in an compressed ZIP-file.
-        zip: bool,
-        partition_by: ExportPartition,
-    },
 }
 
 /// Different strategies how it is decided when corpora need to be removed from the cache.
@@ -1357,64 +1305,53 @@ impl CorpusStorage {
     /// - `corpora` - The corpora to include in the exported file(s).
     /// - `path` - The location on the file system where the corpus data should be written to.
     /// - `format` - The format in which this corpus data will be stored stored.
-    pub fn export_to_fs<S: AsRef<str>, F: Into<ExportFormatOptions>>(
+    pub fn export_to_fs<S: AsRef<str>>(
         &self,
         corpora: &[S],
         path: &Path,
-        format: F,
+        format: ExportFormat,
     ) -> Result<()> {
-        let format_options: ExportFormatOptions = format.into();
-
-        match format_options {
-            ExportFormatOptions::GraphML { zip, .. } => {
-                // If we get a graphml file as path, assume we shall export to a single file, otherwise a directory
-                if let Some(ext) = path.extension()
-                    && ext == "graphml"
-                    && zip == false
-                {
-                    if corpora.len() == 1 {
-                        self.export_corpus_graphml(corpora[0].as_ref(), path)?;
-                    } else {
-                        return Err(CorpusStorageError::MultipleCorporaForSingleCorpusFormat(
-                            corpora.len(),
-                        )
-                        .into());
-                    }
-                } else if zip {
-                    let output_file = File::create(path)?;
-                    let mut zip = zip::ZipWriter::new(output_file);
-
-                    let use_corpus_subdirectory = corpora.len() > 1;
-                    for corpus_name in corpora {
-                        // Add the GraphML file to the ZIP file
-                        let corpus_name: &str = corpus_name.as_ref();
-                        self.export_to_zip(
-                            corpus_name,
-                            use_corpus_subdirectory,
-                            &mut zip,
-                            |status| {
-                                info!("{}", status);
-                            },
-                        )?;
-                    }
-
-                    zip.finish()?;
+        match format {
+            ExportFormat::GraphML => {
+                if corpora.len() == 1 {
+                    self.export_corpus_graphml(corpora[0].as_ref(), path)?;
                 } else {
-                    let use_corpus_subdirectory = corpora.len() > 1;
-                    for corpus_name in corpora {
-                        let mut path = PathBuf::from(path);
-                        if use_corpus_subdirectory {
-                            // Use a sub-directory with the corpus name to avoid conflicts with the
-                            // linked files
-                            path.push(corpus_name.as_ref());
-                        };
-                        std::fs::create_dir_all(&path)?;
-                        path.push(format!("{}.graphml", corpus_name.as_ref()));
-                        self.export_corpus_graphml(corpus_name.as_ref(), &path)?;
-                    }
+                    return Err(CorpusStorageError::MultipleCorporaForSingleCorpusFormat(
+                        corpora.len(),
+                    )
+                    .into());
                 }
             }
-        };
+            ExportFormat::GraphMLDirectory => {
+                let use_corpus_subdirectory = corpora.len() > 1;
+                for corpus_name in corpora {
+                    let mut path = PathBuf::from(path);
+                    if use_corpus_subdirectory {
+                        // Use a sub-directory with the corpus name to avoid conflicts with the
+                        // linked files
+                        path.push(corpus_name.as_ref());
+                    };
+                    std::fs::create_dir_all(&path)?;
+                    path.push(format!("{}.graphml", corpus_name.as_ref()));
+                    self.export_corpus_graphml(corpus_name.as_ref(), &path)?;
+                }
+            }
+            ExportFormat::GraphMLZip => {
+                let output_file = File::create(path)?;
+                let mut zip = zip::ZipWriter::new(output_file);
+
+                let use_corpus_subdirectory = corpora.len() > 1;
+                for corpus_name in corpora {
+                    // Add the GraphML file to the ZIP file
+                    let corpus_name: &str = corpus_name.as_ref();
+                    self.export_to_zip(corpus_name, use_corpus_subdirectory, &mut zip, |status| {
+                        info!("{}", status);
+                    })?;
+                }
+
+                zip.finish()?;
+            }
+        }
 
         Ok(())
     }

--- a/graphannis/src/annis/db/corpusstorage.rs
+++ b/graphannis/src/annis/db/corpusstorage.rs
@@ -532,7 +532,7 @@ impl CorpusStorage {
         info!(
             "saving corpus configuration file for corpus {} to {}",
             corpus_name,
-            &corpus_config_path.to_string_lossy()
+            corpus_config_path.to_string_lossy()
         );
         std::fs::write(corpus_config_path, toml::to_string(&config)?)?;
         Ok(())
@@ -1085,7 +1085,7 @@ impl CorpusStorage {
         info!(
             "Saving corpus configuration file for corpus {} to {}",
             corpus_name,
-            &corpus_config_path.to_string_lossy()
+            corpus_config_path.to_string_lossy()
         );
         std::fs::write(corpus_config_path, toml::to_string(&config)?)?;
 

--- a/graphannis/src/annis/db/corpusstorage.rs
+++ b/graphannis/src/annis/db/corpusstorage.rs
@@ -25,6 +25,7 @@ use graphannis_core::annostorage::{
     NodeAnnotationStorage, match_group_resolve_symbol_ids, match_group_with_symbol_ids,
 };
 use graphannis_core::errors::Result as CoreResult;
+use graphannis_core::graph::serialization::graphml;
 use graphannis_core::{
     annostorage::{MatchGroup, ValueSearch},
     graph::{
@@ -950,26 +951,37 @@ impl CorpusStorage {
                 } else {
                     "UnknownCorpus".to_string()
                 };
-                let input_file = File::open(path)?;
 
-                // Always buffer the read operations
-                let mut input = BufReader::new(input_file);
                 let mut g = AnnotationGraph::with_default_graphstorages(disk_based)?;
                 let mut updates = GraphUpdate::default();
                 let mut edge_updates = GraphUpdate::default();
 
-                // read in all nodes and edges, collecting annotation keys on the fly
-                progress_callback("reading GraphML");
-                let config_str = graphannis_core::graph::serialization::graphml::read_graphml::<
-                    AnnotationComponentType,
-                    _,
-                    _,
-                >(
-                    &mut input,
-                    &mut updates,
-                    &mut edge_updates,
-                    &progress_callback,
-                )?;
+                let mut first_config_str = None;
+
+                for (i, input_path) in graphml::files_for_corpus(path)?.iter().enumerate() {
+                    // Always buffer the read operations
+                    let input_file = File::open(input_path)?;
+                    let mut input = BufReader::new(input_file);
+
+                    // read in all nodes and edges, collecting annotation keys on the fly
+                    progress_callback(&format!(
+                        "reading GraphML file {}",
+                        input_path.to_string_lossy()
+                    ));
+                    let config_str = graphannis_core::graph::serialization::graphml::read_graphml::<
+                        AnnotationComponentType,
+                        _,
+                        _,
+                    >(
+                        &mut input,
+                        &mut updates,
+                        &mut edge_updates,
+                        &progress_callback,
+                    )?;
+                    if i == 0 {
+                        first_config_str = config_str;
+                    }
+                }
 
                 // Append all edges updates after the node updates:
                 // edges would not be added if the nodes they are referring do not exist
@@ -990,7 +1002,7 @@ impl CorpusStorage {
                     g.optimize_gs_impl(&c)?;
                 }
 
-                let config = if let Some(config_str) = config_str {
+                let config = if let Some(config_str) = first_config_str {
                     toml::from_str(&config_str)?
                 } else {
                     CorpusConfiguration::default()

--- a/graphannis/src/annis/db/exec/mod.rs
+++ b/graphannis/src/annis/db/exec/mod.rs
@@ -161,15 +161,12 @@ impl ExecutionNodeDesc {
 
             result.push_str(&format!(
                 "#{} ({}) [{}] {}\n",
-                &node_nr.to_string(),
-                &self.query_fragment,
-                &cost_str,
-                &self.impl_description,
+                node_nr, self.query_fragment, cost_str, self.impl_description,
             ));
         } else {
             result.push_str(&format!(
                 "+|{} ({}) [{}]\n",
-                &self.impl_description, &self.query_fragment, &cost_str
+                self.impl_description, self.query_fragment, cost_str
             ));
 
             let new_indention = format!("{}    ", indention);

--- a/graphannis/src/annis/db/exec/nodesearch.rs
+++ b/graphannis/src/annis/db/exec/nodesearch.rs
@@ -311,23 +311,23 @@ impl fmt::Display for NodeSearchSpec {
             }
             NodeSearchSpec::NotExactValue { ns, name, val, .. } => {
                 if let Some(ns) = ns {
-                    write!(f, "{}:{}!=\"{}\"", ns, name, &val)
+                    write!(f, "{}:{}!=\"{}\"", ns, name, val)
                 } else {
-                    write!(f, "{}!=\"{}\"", name, &val)
+                    write!(f, "{}!=\"{}\"", name, val)
                 }
             }
             NodeSearchSpec::RegexValue { ns, name, val, .. } => {
                 if let Some(ns) = ns {
-                    write!(f, "{}:{}=/{}/", ns, name, &val)
+                    write!(f, "{}:{}=/{}/", ns, name, val)
                 } else {
-                    write!(f, "{}=/{}/", name, &val)
+                    write!(f, "{}=/{}/", name, val)
                 }
             }
             NodeSearchSpec::NotRegexValue { ns, name, val, .. } => {
                 if let Some(ns) = ns {
-                    write!(f, "{}:{}!=/{}/", ns, name, &val)
+                    write!(f, "{}:{}!=/{}/", ns, name, val)
                 } else {
-                    write!(f, "{}!=/{}/", name, &val)
+                    write!(f, "{}!=/{}/", name, val)
                 }
             }
             NodeSearchSpec::ExactTokenValue { val, leafs_only } => {

--- a/graphannis/src/annis/db/exec/parallel/indexjoin.rs
+++ b/graphannis/src/annis/db/exec/parallel/indexjoin.rs
@@ -243,28 +243,22 @@ impl Iterator for IndexJoin<'_> {
     fn next(&mut self) -> Option<Self::Item> {
         // lazily initialize
         if self.match_receiver.is_none() {
-            self.match_receiver = if let Some(rhs) = self.next_match_receiver() {
+            self.match_receiver = {
+                let rhs = self.next_match_receiver()?;
                 Some(rhs)
-            } else {
-                return None;
             };
         }
 
         loop {
-            {
-                let match_receiver = self.match_receiver.as_mut()?;
-                if let Ok(result) = match_receiver.recv() {
-                    return Some(result);
-                }
+            let match_receiver = self.match_receiver.as_mut()?;
+            if let Ok(result) = match_receiver.recv() {
+                return Some(result);
             }
 
-            // inner was completed once, get new candidates
-            if let Some(rhs) = self.next_match_receiver() {
-                self.match_receiver = Some(rhs);
-            } else {
-                // no more results to fetch
-                return None;
-            }
+            // inner was completed once, get new candidates or return if no more
+            // results to fetch
+            let rhs = self.next_match_receiver()?;
+            self.match_receiver = Some(rhs);
         }
     }
 }

--- a/graphannis/src/annis/db/exec/parallel/indexjoin.rs
+++ b/graphannis/src/annis/db/exec/parallel/indexjoin.rs
@@ -74,7 +74,7 @@ impl<'a> IndexJoin<'a> {
                 lhs_desc.as_ref(),
                 rhs_desc,
                 "indexjoin (parallel)",
-                &format!("#{} {} #{}", op_args.left, &op, op_args.right),
+                &format!("#{} {} #{}", op_args.left, op, op_args.right),
                 &processed_func,
             )?,
             lhs: lhs_peek,

--- a/graphannis/src/annis/db/exec/parallel/nestedloop.rs
+++ b/graphannis/src/annis/db/exec/parallel/nestedloop.rs
@@ -284,28 +284,22 @@ impl Iterator for NestedLoop<'_> {
     fn next(&mut self) -> Option<Self::Item> {
         // lazily initialize
         if self.match_receiver.is_none() {
-            self.match_receiver = if let Some(rhs) = self.next_match_receiver() {
+            self.match_receiver = {
+                let rhs = self.next_match_receiver()?;
                 Some(rhs)
-            } else {
-                return None;
             };
         }
 
         loop {
-            {
-                let match_receiver = self.match_receiver.as_mut()?;
-                if let Ok(result) = match_receiver.recv() {
-                    return Some(result);
-                }
+            let match_receiver = self.match_receiver.as_mut()?;
+            if let Ok(result) = match_receiver.recv() {
+                return Some(result);
             }
 
-            // get new candidates
-            if let Some(rhs) = self.next_match_receiver() {
-                self.match_receiver = Some(rhs);
-            } else {
-                // no more results to fetch
-                return None;
-            }
+            // get new candidates or return if there are no more results to
+            // fetch
+            let rhs = self.next_match_receiver()?;
+            self.match_receiver = Some(rhs);
         }
     }
 }

--- a/graphannis/src/annis/db/relannis.rs
+++ b/graphannis/src/annis/db/relannis.rs
@@ -1603,7 +1603,7 @@ where
 
     info!(
         "creating index for content of {}",
-        &node_tab_path.to_string_lossy()
+        node_tab_path.to_string_lossy()
     );
     id_to_node_name.compact()?;
     nodes_by_text.compact()?;
@@ -1886,7 +1886,7 @@ where
 
     info!(
         "creating index for content of {}",
-        &rank_tab_path.to_string_lossy()
+        rank_tab_path.to_string_lossy()
     );
     load_rank_result.components_by_pre.compact()?;
     load_rank_result.edges_by_pre.compact()?;
@@ -2151,7 +2151,7 @@ fn add_subcorpora(
         if let Some(corpus_ref) = text_key.corpus_ref {
             let text_name = utf8_percent_encode(&text.name, NODE_NAME_ENCODE_SET).to_string();
             let subcorpus_full_name = get_corpus_path(corpus_ref, corpus_table)?;
-            let text_full_name = format!("{}#{}", &subcorpus_full_name, &text_name);
+            let text_full_name = format!("{}#{}", subcorpus_full_name, text_name);
 
             updates.add_event(UpdateEvent::AddNode {
                 node_name: text_full_name.clone(),

--- a/webservice/src/api/administration.rs
+++ b/webservice/src/api/administration.rs
@@ -142,7 +142,7 @@ pub async fn import_corpus(
             settings.database.disk_based,
             params.override_existing,
             |status| {
-                info!("Job {} update: {}", &id_as_string, status);
+                info!("Job {} update: {}", id_as_string, status);
                 // Add status report to background job messages
                 if let Ok(mut jobs) = background_jobs.jobs.lock()
                     && let Some(j) = jobs.get_mut(&id)
@@ -201,7 +201,7 @@ fn export_corpus_background_taks(
         // Add the GraphML file to the ZIP file
         let corpus_name: &str = corpus_name.as_ref();
         cs.export_to_zip(corpus_name, use_corpus_subdirectory, &mut zip, |status| {
-            info!("Job {} update: {}", &id_as_string, status);
+            info!("Job {} update: {}", id_as_string, status);
             // Add status report to background job messages
             if let Ok(mut jobs) = background_jobs.jobs.lock()
                 && let Some(j) = jobs.get_mut(&id)

--- a/webservice/src/main.rs
+++ b/webservice/src/main.rs
@@ -117,7 +117,7 @@ fn init_app_state() -> anyhow::Result<(graphannis::CorpusStorage, settings::Sett
         PathBuf::from(&settings.database.sqlite)
             .canonicalize()?
             .to_string_lossy(),
-        &settings.database.cache
+        settings.database.cache
     );
     if let Some(timeout) = &settings.database.query_timeout {
         info!("Queries timeout set to {} seconds", timeout);
@@ -275,7 +275,7 @@ async fn main() -> Result<()> {
     let (cs, settings, db_pool) = init_app_state()
         .map_err(|e| Error::other(format!("Could not initialize graphANNIS service: {:?}", e)))?;
 
-    let bind_address = format!("{}:{}", &settings.bind.host, &settings.bind.port);
+    let bind_address = format!("{}:{}", settings.bind.host, settings.bind.port);
     let cs = web::Data::new(cs);
     let settings = web::Data::new(settings);
     let db_pool = web::Data::new(db_pool);


### PR DESCRIPTION
In partioned GraphML, the corpus is split up into several files, e.g. one per each document.
If a subdirectory with the same base name as the imported GraphML file exist next to it, we assume that all GraphML-files in this subdirectory also belong to this corpus.

This PR does only adds support to import these kind of partitioned corpora and adds helper functions that make it easier for other tools (e.g. annatto) to handle these kind of scenarios.