### PR TITLE
Only add comment to PR if it is not coming from a fork

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -61,6 +61,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           COMMENT_OUTPUT: TRUE
       - uses: mshick/add-pr-comment@v3
+        # Check if the event is not triggered by a fork before attempting to add a comment
+        # see https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#restrictions-on-repository-forks
+        if: github.event.pull_request.head.repo.full_name == github.repository
         with:
           message: |
             Commit ${{ github.event.pull_request.head.sha }}

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To run all checks that have to pass for a merge requests locally, first make sur
 
 ```bash
 cargo install cargo-llvm-cov
-pipx install diff_cover
+pipx install diff-cover
 ```
 
 Then, run the following command to run all checks including code coverage:


### PR DESCRIPTION
Writing to the PR (e.g. adding a comment) won't work: https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#restrictions-on-repository-forks